### PR TITLE
feat: Setup queue API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,12 +22,36 @@ const contentApiPreparePathService = require('./content-api/services/prepare-pat
 const contentApiByPathService = require('./content-api/services/by-path');
 const contentApiPathRoutes = require('./content-api/routes/path');
 
+// Queue API
+const queueApiQueueSchema = require('./queue/content-types/queue/schema.json');
+const queueApiJobSchema = require('./queue/content-types/job/schema.json');
+const queueApiQueueService = require('./queue/services/queue');
+const queueApiQueueHelperService = require('./queue/services/helpers');
+// const { getPluginService } = require('./util/getPluginService');
+
 module.exports = {
   register: async ({ strapi }) => {
     await adminApiRegister(strapi);
   },
   bootstrap: async () => {
     await adminApiBootstrap();
+
+    // const queueName = 'url-alias creation queue 9';
+    // await getPluginService('queueService').process(queueName, async (job, done) => {
+    //   console.log('we be processing the job breh', job.data);
+    //   done();
+    // });
+
+    // await getPluginService('queueService').create(queueName);
+    // await getPluginService('queueService').addJob(queueName, {
+    //   some: 'data',
+    // });
+    // await getPluginService('queueService').addJob(queueName, {
+    //   some: 'more data',
+    // });
+    // await getPluginService('queueService').addJob(queueName, {
+    //   some: 'even data',
+    // });
   },
   contentTypes: {
     path: {
@@ -35,6 +59,12 @@ module.exports = {
     },
     pattern: {
       schema: adminApiPatternSchema,
+    },
+    queue: {
+      schema: queueApiQueueSchema,
+    },
+    job: {
+      schema: queueApiJobSchema,
     },
   },
   routes: {
@@ -66,5 +96,7 @@ module.exports = {
     lifecycleService: adminApiLifecycleService,
     byPathService: contentApiByPathService,
     overrideQueryLayer: adminApiOverrideQueryLayerService,
+    queueService: queueApiQueueService,
+    queueHelpers: queueApiQueueHelperService,
   },
 };

--- a/server/queue/bootstrap.js
+++ b/server/queue/bootstrap.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async () => {
+
+};

--- a/server/queue/content-types/job/schema.json
+++ b/server/queue/content-types/job/schema.json
@@ -1,0 +1,34 @@
+{
+  "kind": "collectionType",
+  "collectionName": "queue_job",
+  "info": {
+    "singularName": "job",
+    "pluralName": "jobs",
+    "displayName": "job",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false,
+    "comment": ""
+  },
+  "pluginOptions": {
+    "content-manager": {
+      "visible": true
+    },
+    "content-type-builder": {
+      "visible": true
+    }
+  },
+  "attributes": {
+    "queue": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::url-alias.queue",
+      "inversedBy": "queue_jobs"
+    },
+    "data": {
+      "type": "json",
+      "required": true
+    }
+  }
+}

--- a/server/queue/content-types/queue/schema.json
+++ b/server/queue/content-types/queue/schema.json
@@ -1,0 +1,45 @@
+{
+  "kind": "collectionType",
+  "collectionName": "queue",
+  "info": {
+    "singularName": "queue",
+    "pluralName": "queues",
+    "displayName": "queue",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false,
+    "comment": ""
+  },
+  "pluginOptions": {
+    "content-manager": {
+      "visible": true
+    },
+    "content-type-builder": {
+      "visible": true
+    }
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "unique": true,
+      "required": true
+    },
+    "progress": {
+      "required": true,
+      "min": 0,
+      "max": 100,
+      "default": 0,
+      "type": "integer"
+    },
+    "paused": {
+      "type": "boolean"
+    },
+    "queue_jobs": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "plugin::url-alias.job",
+      "mappedBy": "queue"
+    }
+  }
+}

--- a/server/queue/services/helpers.js
+++ b/server/queue/services/helpers.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const { getPluginService } = require('../../util/getPluginService');
+
+module.exports = () => ({
+  /**
+   * Get a queue by it's name.
+   *
+   * @param {string} name the name.
+   * @returns {void}
+   */
+  getQueue: async (name) => {
+    try {
+      const queues = await strapi.entityService.findMany('plugin::url-alias.queue', {
+        filters: {
+          name,
+        },
+        populate: {
+          queue_jobs: true,
+        },
+      });
+
+      return queues[0];
+    } catch (e) {
+      strapi.log.error(e);
+    }
+  },
+
+  /**
+   * Create a job.
+   *
+   * @param {string} queueId the id of the queue.
+   * @param {object} data the data of the job.
+   * @returns {void}
+   */
+   createJob: async (queueId, data) => {
+    try {
+      return await strapi.entityService.create('plugin::url-alias.job', {
+        data: {
+          data,
+          queue: queueId,
+        },
+      });
+    } catch (e) {
+      strapi.log.error(e);
+    }
+  },
+
+  /**
+   * Deletes a job.
+   *
+   * @param {obj} job the job to delete.
+   * @returns {void}
+   */
+   deleteJob: async (job) => {
+    try {
+      await strapi.entityService.delete('plugin::url-alias.job', job.id);
+    } catch (e) {
+      strapi.log.error(e);
+    }
+  },
+
+  /**
+   * Update the progress
+   *
+   * @param {number} queueId the id of the queue to update.
+   * @param {number} progress the new progress.
+   * @returns {void}
+   */
+   updateProgress: async (queueId, progress) => {
+    try {
+      await strapi.entityService.update('plugin::url-alias.queue', queueId, {
+        data: {
+          progress: Math.floor(progress),
+        },
+      });
+    } catch (e) {
+      strapi.log.error(e);
+    }
+  },
+});

--- a/server/queue/services/queue.js
+++ b/server/queue/services/queue.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { getPluginService } = require('../../util/getPluginService');
+
+module.exports = () => ({
+  /**
+   * Create queue.
+   *
+   * @param {string} name the name.
+   * @returns {void}
+   */
+  create: async (name) => {
+    try {
+      return await strapi.entityService.create('plugin::url-alias.queue', {
+        data: {
+          name,
+        },
+      });
+    } catch (e) {
+      strapi.log.error(e);
+    }
+  },
+
+  /**
+   * Add job.
+   *
+   * @param {string} name the name of the queue.
+   * @param {object} data the data of the job.
+   * @returns {void}
+   */
+   addJob: async (name, data) => {
+    try {
+      const queue = await getPluginService('queueHelpers').getQueue(name);
+      await getPluginService('queueHelpers').createJob(queue.id, data);
+    } catch (e) {
+      strapi.log.error(e);
+    }
+  },
+
+  /**
+   * Process the queue.
+   *
+   * @param {string} name the name of the queue.
+   * @param {function} fn the process function.
+   * @returns {void}
+   */
+   process: async (name, fn) => {
+    const queue = await getPluginService('queueHelpers').getQueue(name);
+    const queueSizeOnePercent = queue.queue_jobs.length / 100;
+    let queueSize = queue.queue_jobs.length;
+
+    const done = async (job) => {
+      await getPluginService('queueHelpers').deleteJob(job);
+      queueSize--;
+      const progress = 100 - (queueSize / queueSizeOnePercent);
+      await getPluginService('queueHelpers').updateProgress(queue.id, progress);
+    };
+
+    queue.queue_jobs.map((job) => {
+      fn(job, () => done(job));
+    });
+
+    // TODO:
+    // Delete the queue.
+  },
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### Queue documentation

To solve #14 we need queueing. This PR is a setup for a queue system. Here some docs:

**Create queue**
To create a queue you have to call the `create` service which takes one parameter that is a string that is unique to your queue. We refer to this as the name of the queue.

```
const { getPluginService } = require('./util/getPluginService');

getPluginService('queueService').create("my queue");
```

**Add jobs**
Once you have created your queue you have to add jobs to it. You can do that by calling the `addJob` service which takes two parameters. The first being the name of the queue, and the second being the data of the job.

```
await getPluginService('queueService').addJob("my queue", {
  some: 'data',
});
await getPluginService('queueService').addJob("my queue", {
  some: 'more data',
});
await getPluginService('queueService').addJob("my queue", {
  some: 'even data',
});
```

**Process queue**
After creating your queue and adding your jobs you have to process the queue. You can do that by calling the `process` service which takes two parameters. The first being the name of the queue, the second is a function that will be called to process a single job.

```
await getPluginService('queueService').process("my queue", async (job, done) => {
  // job.data is the job data.
  console.log('we be processing the job breh', job.data);

  // Call the done function when you're done processing the job.
  done();
});
```
