### PR TITLE
fix: hack for permissions issue #22

### DIFF
--- a/server/admin-api/controllers/path.js
+++ b/server/admin-api/controllers/path.js
@@ -7,6 +7,9 @@ const { getPluginService } = require('../../util/getPluginService');
  */
 
 module.exports = {
+  // Hack, placeholder for generate correct permissions (https://github.com/strapi-community/strapi-plugin-url-alias/issues/22)
+  find: async (ctx) => {
+  },
   findOne: async (ctx) => {
     try {
       const { id } = ctx.params;

--- a/server/content-api/routes/path.js
+++ b/server/content-api/routes/path.js
@@ -1,6 +1,15 @@
 'use strict';
 
 module.exports = [
+  // Hack, placeholder for generate correct permissions (https://github.com/strapi-community/strapi-plugin-url-alias/issues/22)
+  {
+    method: "GET",
+    path: "/find",
+    handler: "path.find",
+    config: {
+      policies: [],
+    },
+  },
   {
     method: "GET",
     path: "/get",


### PR DESCRIPTION
### What does it do?

Hello, this is ~~hack~~ fix for #22

### Why is it needed?

Since strapi 4.4 there is no way to just add permissions to database, strapi will remove it on each start, and if it added after strapi startup - then it will be ignored with error message:
```
[2022-10-20 08:55:26.802] debug: Unknown action "plugin::url-alias.path.find" supplied when registering a new permission
```

### How to test it?

Check that permission "plugin::url-alias.path.find" appears on empty database

### Related issue(s)/PR(s)

- #22 
