### PR TITLE
chore(playground): Fixed database path

### DIFF
--- a/playground/config/database.ts
+++ b/playground/config/database.ts
@@ -4,7 +4,13 @@ module.exports = ({ env }) => ({
   connection: {
     client: 'sqlite',
     connection: {
-      filename: path.join(__dirname, '..', env('DATABASE_FILENAME', '.tmp/data.db')),
+      filename: path.join(
+        __dirname,
+        '..',
+        // We need to go back once more to get out of the dist folder
+        '..',
+        env('DATABASE_FILENAME', '.tmp/data.db')
+      ),
     },
     useNullAsDefault: true,
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

The database path in playground needs to escape the dist folder so we need to add an extra ".."
I am not sure if you are experiencing the same.

### Why is it needed?

I had an issue doing anything in the playground becuase the database folder would be created inside the dist folder.