### PR TITLE
fix(migration): should rename table if it exists and await transactions

### DIFF
--- a/migrations/2023.06.12T00.00.00.url-alias-to-webtools.js
+++ b/migrations/2023.06.12T00.00.00.url-alias-to-webtools.js
@@ -12,17 +12,24 @@
 module.exports = {
   async up(knex) {
     // Rename the url_paths table.
-    knex.schema.hasTable('url_paths').then((exists) => {
-      if (!exists) {
-        knex.schema.renameTable('url_paths', 'wt_url_alias');
-      }
-    });
+    const hasUrlPathsTable = await knex.schema.hasTable('url_paths');
+    if (hasUrlPathsTable) {
+      console.log('Renaming "url_paths" table to "wt_url_alias"...');
+      await knex.schema.renameTable('url_paths', 'wt_url_alias');
+      console.log('Renamed "url_paths" table to "wt_url_alias".');
+    } else {
+      console.log('No url_paths table found. Skipping...');
+    }
 
     // Rename the url_patterns table.
-    knex.schema.hasTable('url_patterns').then((exists) => {
-      if (!exists) {
-        knex.schema.renameTable('url_patterns', 'wt_url_patterns');
-      }
-    });
+    const hasUrlPatternsTable = await knex.schema.hasTable('url_patterns');
+    if (hasUrlPatternsTable) {
+      console.log('Renaming "url_patterns" table to "wt_url_patterns"...');
+      await knex.schema.renameTable('url_patterns', 'wt_url_patterns');
+      console.log('Renamed "url_patterns" table to "wt_url_patterns".');
+    } else {
+      console.log('No url_patterns table found. Skipping...');
+    }
   },
 };
+


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

I was trying to migrate one of my live deployments in a staging environment and the migration script said it had run, but the table wasn't renamed and then the old tables were deleted.

I noticed that the code only runs the renaming if the table does not exist :thinking:, this should be fixed now.

Also, I couldn't get the script to work without awaiting the transactions.

I also added some console logs, so it may be easy to notice if anything goes wrong or something unexpected happens.