### PR TITLE
fix: Log the migrations to the database to fix #102

### DIFF
--- a/.changeset/dull-sheep-develop.md
+++ b/.changeset/dull-sheep-develop.md
@@ -1,0 +1,5 @@
+---
+"@pluginpal/webtools-core": patch
+---
+
+Log the migrations to the database to fix #102

--- a/packages/core/server/admin-api/bootstrap.ts
+++ b/packages/core/server/admin-api/bootstrap.ts
@@ -3,14 +3,14 @@ import { IStrapi } from '../types/strapi';
 import migrateToNativeRelation from './migrations/to-native-relation';
 import migratePluginOptionsRename from './migrations/plugin-options-rename';
 
-export default (strapi: IStrapi) => {
+export default async (strapi: IStrapi) => {
   try {
     // Decorate the entity service with review workflow logic
     const { decorator } = getPluginService('queryLayerDecorator');
     strapi.entityService.decorate(decorator);
 
     // Migrate to a native relation.
-    migrateToNativeRelation(strapi);
+    await migrateToNativeRelation(strapi);
 
     // Migrate the pluginOptions to reflect the plugin rename.
     migratePluginOptionsRename(strapi);

--- a/packages/core/server/admin-api/migrations/to-native-relation.ts
+++ b/packages/core/server/admin-api/migrations/to-native-relation.ts
@@ -1,37 +1,50 @@
-import _ from 'lodash';
-import { Schema } from '@strapi/strapi';
-import { IStrapi } from '../../types/strapi';
+import { Schema, Strapi } from '@strapi/strapi';
 
-const migrateToNativeRelation = (strapi: IStrapi) => {
-  Object.values(strapi.contentTypes).map(async (contentType: Schema.ContentType) => {
-    const notMigrated = _.get(contentType.pluginOptions, ['url-alias', 'enabled'], false) as boolean;
+const migrateToNativeRelation = async (strapi: Strapi) => {
+  await Promise.all(
+    Object.values(strapi.contentTypes).map(async (
+      contentType: Schema.ContentType,
+    ) => {
+      const notMigrated = await strapi.db.getSchemaConnection().hasColumn(contentType.collectionName, 'url_path_id');
 
-    // Return when the migration is allready finished.
-    if (!notMigrated) {
-      return;
-    }
+      // Return when the migration is allready finished.
+      if (!notMigrated) {
+        return;
+      }
 
-    const pagesToBeMigrated = await strapi.entityService.findMany(contentType.uid, {
-      // @ts-ignore
-      fields: 'url_path_id',
-      filters: {
+      // Find the pages that need migration.
+      const pagesToBeMigrated = await strapi.entityService.findMany(contentType.uid, {
         // @ts-ignore
-        url_path_id: {
-          $notNull: true,
-        },
-      },
-    });
-
-    pagesToBeMigrated.map(async (page) => {
-      await strapi.entityService.update(contentType.uid, page.id, {
-        data: {
+        fields: 'url_path_id',
+        filters: {
           // @ts-ignore
-          url_alias: Number(page.url_path_id),
-          url_path_id: null,
+          url_path_id: {
+            $notNull: true,
+          },
         },
       });
-    });
-  });
+
+      // Migrate those fields.
+      await Promise.all(pagesToBeMigrated.map(async (page) => {
+        await strapi.entityService.update(contentType.uid, page.id, {
+          data: {
+            // @ts-ignore
+            url_alias: Number(page.url_path_id),
+            url_path_id: null,
+          },
+        });
+      }));
+    }),
+  );
+
+  // Log the migration in the database.
+  await strapi.db
+    .getConnection()
+    .insert({
+      name: 'to-native-relation',
+      time: new Date(),
+    })
+    .into('strapi_migrations');
 };
 
 export default migrateToNativeRelation;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?
It will log the `to-native-relation.ts` migration to the `strapi_migrations` database table.
Then we use that datbase entry to check whether the migration have / haven't finished.

### Why is it needed?

To prevent the migrations not running in different environments

### Related issue(s)/PR(s)
#102 
