### PR TITLE
fix(urlAliasService): Use the duplicate checked url path

### DIFF
--- a/.changeset/dry-lions-wonder.md
+++ b/.changeset/dry-lions-wonder.md
@@ -1,0 +1,5 @@
+---
+"@pluginpal/webtools-core": patch
+---
+
+Will no longer fail when trying to generate a path that initially already exists.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Prior to this commit, the duplicate check was run, but the new url path was not used.
This commit also refactors the duplicateCheck function to a separate function without side effects.

### Why is it needed?

The duplicate check needs to run and use the new url path
