### PR TITLE
feat: Added an extra admin permission to grant/revoke acces to the UR…

### DIFF
--- a/.changeset/eighty-taxis-shout.md
+++ b/.changeset/eighty-taxis-shout.md
@@ -1,0 +1,5 @@
+---
+"@pluginpal/webtools-core": minor
+---
+
+Added an extra admin permission to grant/revoke acces to the URL alias sidebar (#55)

--- a/packages/core/admin/components/EditView/index.tsx
+++ b/packages/core/admin/components/EditView/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { SidebarModal } from '@pluginpal/webtools-helper-plugin';
 
-import { useCMEditViewDataManager } from '@strapi/helper-plugin';
+import { useCMEditViewDataManager, CheckPermissions } from '@strapi/helper-plugin';
 
 import getTrad from '../../helpers/getTrad';
 import EditForm from '../EditForm';
@@ -10,6 +10,7 @@ import Permalink from './Permalink';
 import { createUrlAlias, updateUrlAlias } from '../../api/url-alias';
 import { isContentTypeEnabled } from '../../../server/util/enabledContentTypes';
 import { UrlAliasEntity } from '../../types/url-aliases';
+import pluginPermissions from '../../permissions';
 
 const EditView = () => {
   const { formatMessage } = useIntl();
@@ -35,7 +36,7 @@ const EditView = () => {
   };
 
   return (
-    <>
+    <CheckPermissions permissions={pluginPermissions['edit-view.sidebar']}>
       <SidebarModal
         label={formatMessage({
           id: getTrad('plugin.name'),
@@ -55,7 +56,7 @@ const EditView = () => {
       <Permalink
         path={modifiedUrlAlias?.url_path}
       />
-    </>
+    </CheckPermissions>
   );
 };
 

--- a/packages/core/admin/permissions.ts
+++ b/packages/core/admin/permissions.ts
@@ -6,6 +6,7 @@ const pluginPermissions = {
   'settings.list': [{ action: 'plugin::webtools.settings.list', subject: null }],
   // 'settings.overview': [{ action: 'plugin::webtools.settings.overview', subject: null }],
   'settings.patterns': [{ action: 'plugin::webtools.settings.patterns', subject: null }],
+  'edit-view.sidebar': [{ action: 'plugin::webtools.edit-view.sidebar', subject: null }],
 };
 
 export default pluginPermissions;

--- a/packages/core/server/admin-api/bootstrap.ts
+++ b/packages/core/server/admin-api/bootstrap.ts
@@ -29,6 +29,12 @@ export default (strapi: IStrapi) => {
         uid: 'settings.patterns',
         pluginName: 'webtools',
       },
+      {
+        section: 'plugins',
+        displayName: 'Access the URL alias sidebar',
+        uid: 'edit-view.sidebar',
+        pluginName: 'webtools',
+      },
     ];
 
     strapi.admin.services.permission.actionProvider.registerMany(actions);


### PR DESCRIPTION
…L alias sidebar (#55)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Adds a new admin permission `edit-view.sidebar`:

<img width="895" alt="Scherm­afbeelding 2024-01-31 om 16 00 11" src="https://github.com/pluginpal/strapi-webtools/assets/9551934/0253c080-1603-4a86-a318-6e46595e0abe">

### Why is it needed?

To grant/revoke access to the URL alias sidebar.

### How to test it?

1. Make an account as a CMS "editor"
2. Give the editor role the `edit-view.sidebar` permission.
3. Login in with the account that has the editor role.
4. Check if you can see the URL alias sidebar
5. Remove the `edit-view.sidebar` permission.
6. You shouldn't see the URL alias sidebar anymore now.

### Related issue(s)/PR(s)

#55
