### PR TITLE
ci(tests): Does not need to run if only non-js/ts files change

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - './.changeset/**/*'
+      - './migrations/**/*'
+      - './**/*.md'
   pull_request:
     branches:
       - monorepo
       - master
       - develop
+    paths-ignore:
+      - './.changeset/**/*'
+      - './migrations/**/*'
+      - './**/*.md'
 
 jobs:
   lint:


### PR DESCRIPTION
### What does it do?

tests does not need to run if only non-js/ts files change, such as `.md` files

### Why is it needed?

Saves compute time

For reference [Github actions docs for paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)