### PR TITLE
Feature/i18n

### DIFF
--- a/.changeset/eight-drinks-kick.md
+++ b/.changeset/eight-drinks-kick.md
@@ -1,0 +1,5 @@
+---
+"@pluginpal/webtools-core": minor
+---
+
+Multilinguality for patterns and aliases using the @strapi/plugin-i18n package

--- a/.changeset/modern-paws-smell.md
+++ b/.changeset/modern-paws-smell.md
@@ -1,0 +1,5 @@
+---
+"@pluginpal/webtools-core": minor
+---
+
+Add a main menu item for all the admin pages of Webtools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,15 @@ Go to the folder and install the dependencies
 cd strapi-webtools && yarn install
 ```
 
-#### 4. Run the compiler of the plugin 
+#### 4. Install the playground dependencies
+
+Run this in the root of the repository
+
+```bash
+yarn playground:install
+```
+
+#### 5. Run the compiler of the plugin 
 
 As the plugin is written using Typescript you will have to run the typescript compiler during development. Run the following command:
 
@@ -32,7 +40,7 @@ As the plugin is written using Typescript you will have to run the typescript co
 yarn develop
 ```
 
-#### 5. Start the playground instance
+#### 6. Start the playground instance
 
 Leave the typescript compiler running, open up a new terminal window and browse back to the root of the plugin repo. Run the following command:
 
@@ -42,7 +50,7 @@ yarn playground:develop
 
 This will start the playground instance that will have the plugin installed by default. Browse to http://localhost:1337 and create a test admin user to log in to the playground.
 
-#### 6. Start your contribution!
+#### 7. Start your contribution!
 
 You can now start working on your contribution. If you had trouble setting up this testing environment please feel free to report an issue on Github.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,15 +24,7 @@ Go to the folder and install the dependencies
 cd strapi-webtools && yarn install
 ```
 
-#### 4. Install the dependencies of the playground instance
-
-Run the following command
-
-```bash
-yarn playground:install
-```
-
-#### 5. Run the compiler of the plugin 
+#### 4. Run the compiler of the plugin 
 
 As the plugin is written using Typescript you will have to run the typescript compiler during development. Run the following command:
 
@@ -40,7 +32,7 @@ As the plugin is written using Typescript you will have to run the typescript co
 yarn develop
 ```
 
-#### 6. Start the playground instance
+#### 5. Start the playground instance
 
 Leave the typescript compiler running, open up a new terminal window and browse back to the root of the plugin repo. Run the following command:
 
@@ -50,7 +42,7 @@ yarn playground:develop
 
 This will start the playground instance that will have the plugin installed by default. Browse to http://localhost:1337 and create a test admin user to log in to the playground.
 
-#### 7. Start your contribution!
+#### 6. Start your contribution!
 
 You can now start working on your contribution. If you had trouble setting up this testing environment please feel free to report an issue on Github.
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "packages/addons/*"
   ],
   "scripts": {
+    "postinstall": "yarn playground:install",
     "build": "turbo run build",
-    "develop": "turbo run watch:link",
+    "develop": "FORCE_COLOR=1 turbo run watch:link",
     "eslint": "turbo run eslint",
     "eslint:fix": "turbo run eslint:fix",
     "release:publish": "turbo run build && changeset publish",
@@ -15,7 +16,7 @@
     "playground:install": "cd playground && yarn dlx yalc add --link @pluginpal/webtools-core && yarn install",
     "playground:build": "cd playground && yarn build",
     "playground:start": "cd playground && yarn start",
-    "playground:develop": "cd playground && yarn develop --watch-admin --bundler=vite",
+    "playground:develop": "rm -rf playground/node_modules/.strapi/ && cd playground && yarn develop --watch-admin --bundler=vite",
     "test:unit": "ENV_PATH=./playground/.env jest --verbose --runInBand --detectOpenHandles --forceExit",
     "test:integration": "ENV_PATH=./playground/.env jest --verbose --runInBand --detectOpenHandles --forceExit --testMatch '**/healthcheck.test.js'"
   },

--- a/packages/core/admin/components/EditForm/index.tsx
+++ b/packages/core/admin/components/EditForm/index.tsx
@@ -44,7 +44,7 @@ const EditForm = () => {
               defaultMessage: ' Generate automatic URL alias',
             })}
           </Checkbox>
-          <Link to="/settings/webtools/patterns">
+          <Link to="/plugins/webtools/patterns">
             Configure URL alias patterns.
           </Link>
         </Box>

--- a/packages/core/admin/components/EditView/index.tsx
+++ b/packages/core/admin/components/EditView/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { SidebarModal } from '@pluginpal/webtools-helper-plugin';
 
@@ -21,6 +21,21 @@ const EditView = () => {
     onChange,
     slug,
   } = useCMEditViewDataManager();
+
+  const modifiedDataUrlAlias = modifiedData.url_alias as UrlAliasEntity;
+  const i18nLang = new URLSearchParams(window.location.search).get('plugins[i18n][locale]');
+
+  useEffect(() => {
+    // Early return for when the i18n plugin is not enabled.
+    if (!i18nLang) return;
+
+    // If the URL alias is not the same language as the entity,
+    // we should clear it. This happens when you're copying content
+    // from a different locale.
+    if (modifiedDataUrlAlias?.locale !== i18nLang) {
+      onChange({ target: { name: 'url_alias', value: null, type: 'text' } });
+    }
+  }, [modifiedDataUrlAlias, onChange, i18nLang]);
 
   if (!allLayoutData.contentType) return null;
 

--- a/packages/core/admin/components/HiddenLocalizedField/index.tsx
+++ b/packages/core/admin/components/HiddenLocalizedField/index.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import { FormikErrors } from 'formik';
+
+type Props = {
+  localized: boolean;
+  setFieldValue:
+  (field: string, value: any, shouldValidate?: boolean) =>
+  Promise<void | FormikErrors<any>>
+};
+
+const HiddenLocalizedField = (props: Props) => {
+  const { localized, setFieldValue } = props;
+
+  React.useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    setFieldValue('localized', localized);
+  }, [localized, setFieldValue]);
+
+  return null;
+};
+
+export default HiddenLocalizedField;

--- a/packages/core/admin/components/LanguageCheckboxes/index.tsx
+++ b/packages/core/admin/components/LanguageCheckboxes/index.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+
+import {
+  Flex,
+  Checkbox,
+  Field,
+  FieldLabel,
+  FieldError,
+} from '@strapi/design-system';
+import { request } from '@strapi/helper-plugin';
+import { EnabledContentTypes } from '../../types/enabled-contenttypes';
+
+type Props = {
+  selectedLanguages: string[];
+  onChange: (selectedLanguages: string[]) => any;
+  error?: any;
+};
+
+const LanguageCheckboxes = ({
+  selectedLanguages,
+  onChange,
+  error,
+}: Props) => {
+  const [languages, setLanguages] = React.useState<EnabledContentTypes>([]);
+  const [loading, setLoading] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    setLoading(true);
+    request('/webtools/info/getLanguages', { method: 'GET' })
+      .then((res: EnabledContentTypes) => {
+        setLanguages(res);
+        setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <Field name="password" error={error as string}>
+      <FieldLabel>Select the language</FieldLabel>
+      <Flex direction="column" alignItems="start" gap="1" marginTop="2">
+        {languages.map((contentType) => (
+          <Checkbox
+            aria-label={`Select ${contentType.name}`}
+            value={selectedLanguages.includes(contentType.uid)}
+            onValueChange={() => {
+              if (selectedLanguages.includes(contentType.uid)) {
+                const newContentTypes = selectedLanguages
+                  .filter((uid) => uid !== contentType.uid);
+
+                onChange(newContentTypes);
+
+                return;
+              }
+              onChange([...selectedLanguages, contentType.uid]);
+            }}
+          >
+            {contentType.name}
+          </Checkbox>
+        ))}
+        <FieldError />
+      </Flex>
+    </Field>
+  );
+};
+
+export default LanguageCheckboxes;

--- a/packages/core/admin/components/PatternField/index.tsx
+++ b/packages/core/admin/components/PatternField/index.tsx
@@ -1,5 +1,6 @@
 import React, {
   useState, useRef, FC,
+  useEffect,
 } from 'react';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -9,7 +10,6 @@ import {
   TextInput, Popover, Stack, Box, Loader, Typography,
 } from '@strapi/design-system';
 import { request } from '@strapi/helper-plugin';
-import { useQuery } from 'react-query';
 import { PatternFormValues } from '../../types/url-patterns';
 import { Theme } from '../../types/theme';
 
@@ -27,23 +27,29 @@ const PatternField: FC<Props> = ({
   setFieldValue,
 }) => {
   const patternRef = useRef<HTMLDivElement>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingError, setLoadingError] = useState(false);
+  const [allowedFields, setAllowedFields] = useState<Record<string, string[]>>(null);
   const { formatMessage } = useIntl();
 
   const [popoverDismissed, setPopoverDismissed] = useState(false);
-  const {
-    data: allowedFields,
-    isLoading: allowedFieldsLoading,
-    isError,
-  } = useQuery<Record<string, string[]>>(
 
-    ['webtools', 'pattern', 'allowed-fields'],
-    () => request('/webtools/url-pattern/allowed-fields', { method: 'GET' }),
-    {
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-      retry: false,
-    },
-  );
+  useEffect(() => {
+    const fetchAllowedFields = async () => {
+      try {
+        setLoading(true);
+        const data = await request<Record<string, string[]>>('/webtools/url-pattern/allowed-fields', { method: 'GET' });
+        setAllowedFields(data);
+        setLoading(false);
+      } catch (err) {
+        setLoading(false);
+        setLoadingError(true);
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    fetchAllowedFields();
+  }, []);
 
   const HoverBox = styled(Box)`
     cursor: pointer;
@@ -81,11 +87,11 @@ const PatternField: FC<Props> = ({
   };
 
 
-  if (allowedFieldsLoading) {
+  if (loading) {
     return <Loader>{formatMessage({ id: 'webtools.settings.loading', defaultMessage: 'Loading content...' })}</Loader>;
   }
 
-  if (isError || !allowedFields) {
+  if (loadingError || !allowedFields) {
     return <div>{formatMessage({ id: 'webtools.pattern.allowedFields.fetchError', defaultMessage: 'An error occurred while fetching allowed fields' })}</div>;
   }
 

--- a/packages/core/admin/components/PluginIcon/index.tsx
+++ b/packages/core/admin/components/PluginIcon/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/**
+ *
+ * PluginIcon
+ *
+ */
+
+import { Link } from '@strapi/icons';
+
+// eslint-disable-next-line jsx-a11y/anchor-is-valid
+const PluginIcon = () => <Link />;
+
+export { PluginIcon };

--- a/packages/core/admin/containers/App/index.tsx
+++ b/packages/core/admin/containers/App/index.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Route, Switch, useHistory } from 'react-router-dom';
+
+import {
+  Layout,
+  SubNav,
+  SubNavHeader,
+  SubNavSections,
+  SubNavSection,
+  SubNavLink,
+} from '@strapi/design-system';
+import { CheckPagePermissions } from '@strapi/helper-plugin';
+
+import pluginPermissions from '../../permissions';
+import pluginId from '../../helpers/pluginId';
+import Patterns from '../../screens/Patterns';
+import List from '../../screens/List';
+import Overview from '../../screens/Overview';
+
+const App = () => {
+  const history = useHistory();
+
+  if (history.location.pathname === `/plugins/${pluginId}`) {
+    history.replace(`/plugins/${pluginId}/overview`);
+  }
+
+  return (
+    <CheckPagePermissions permissions={pluginPermissions['settings.patterns']}>
+      <Layout
+        sideNav={(
+          <SubNav ariaLabel="Webtools sub nav">
+            <SubNavHeader value="" label="Webtools" />
+            <SubNavSections>
+              <SubNavSection label="Core">
+                <SubNavLink to="/plugins/webtools/overview" key="test">
+                  Overview
+                </SubNavLink>
+                <SubNavLink to="/plugins/webtools/urls" key="test">
+                  All URLs
+                </SubNavLink>
+                <SubNavLink to="/plugins/webtools/patterns" key="test">
+                  Url Patterns
+                </SubNavLink>
+              </SubNavSection>
+              {/* <SubNavSection label="Addons">
+                <SubNavLink to="/test" active key="test">
+                  Sitemap
+                </SubNavLink>
+              </SubNavSection> */}
+            </SubNavSections>
+          </SubNav>
+        )}
+      >
+        <Switch>
+          <Route path={[`/plugins/${pluginId}/overview`, `/plugins/${pluginId}`]} component={Overview} exact />
+          <Route path={`/plugins/${pluginId}/urls`} component={List} exact />
+          <Route
+            path={`/plugins/${pluginId}/patterns`}
+            component={Patterns}
+            exact
+          />
+          {/* <Route path="" component={NotFound} /> */}
+        </Switch>
+      </Layout>
+    </CheckPagePermissions>
+  );
+};
+
+export default App;

--- a/packages/core/admin/containers/App/index.tsx
+++ b/packages/core/admin/containers/App/index.tsx
@@ -57,7 +57,6 @@ const App = () => {
           <Route
             path={`/plugins/${pluginId}/patterns`}
             component={Patterns}
-            exact
           />
           {/* <Route path="" component={NotFound} /> */}
         </Switch>

--- a/packages/core/admin/index.ts
+++ b/packages/core/admin/index.ts
@@ -14,6 +14,7 @@ import CheckboxConfirmation from './components/ContentManagerHooks/ConfirmationC
 
 import dutchTranslations from './translations/nl.json';
 import englishTranslations from './translations/en.json';
+import { PluginIcon } from './components/PluginIcon';
 
 const pluginDescription = pluginPkg.strapi.description || pluginPkg.description;
 const { name } = pluginPkg.strapi;
@@ -28,65 +29,22 @@ export default {
       name,
     });
 
-    app.createSettingSection(
-      {
-        id: pluginId,
-        intlLabel: {
-          id: `${pluginId}.settings.title`,
-          defaultMessage: 'Webtools',
-        },
+    app.addMenuLink({
+      to: '/plugins/webtools',
+      icon: PluginIcon,
+      intlLabel: {
+        id: `${pluginId}.settings.title`,
+        defaultMessage: 'Webtools',
       },
-      [
-        // {
-        //   intlLabel: {
-        //     id: `${pluginId}.settings.page.overview.title`,
-        //     defaultMessage: 'Overview',
-        //   },
-        //   id: 'overview',
-        //   to: `/settings/${pluginId}/overview`,
-        //   Component: async () => {
-        //     const component = await import(
-        //       /* webpackChunkName: "webtools-list" */ './screens/Overview'
-        //     );
+      Component: async () => {
+        const component = await import(
+          /* webpackChunkName: "webtools-list" */ './containers/App'
+        );
 
-        //     return component;
-        //   },
-        //   permissions: pluginPermissions['settings.overview'],
-        // },
-        {
-          intlLabel: {
-            id: `${pluginId}.settings.page.list.title`,
-            defaultMessage: 'All URLs',
-          },
-          id: 'webtools-list',
-          to: `/settings/${pluginId}/list`,
-          Component: async () => {
-            const component = await import(
-              /* webpackChunkName: "webtools-list" */ './screens/List'
-            );
-
-            return component;
-          },
-          permissions: pluginPermissions['settings.list'],
-        },
-        {
-          intlLabel: {
-            id: `${pluginId}.settings.page.patterns.title`,
-            defaultMessage: 'URL patterns',
-          },
-          id: 'webtools-patterns',
-          to: `/settings/${pluginId}/patterns`,
-          Component: async () => {
-            const component = await import(
-              /* webpackChunkName: "webtools-patterns" */ './screens/Patterns'
-            );
-
-            return component;
-          },
-          permissions: pluginPermissions['settings.patterns'],
-        },
-      ],
-    );
+        return component;
+      },
+      permissions: [], // permissions to apply to the link
+    });
   },
   bootstrap(app: AdminApp) {
     app.injectContentManagerComponent('editView', 'right-links', {

--- a/packages/core/admin/index.ts
+++ b/packages/core/admin/index.ts
@@ -8,7 +8,6 @@ import * as yup from 'yup';
 import pluginPkg from '../package.json';
 import EditView from './components/EditView';
 import pluginId from './helpers/pluginId';
-import pluginPermissions from './permissions';
 import getTrad from './helpers/getTrad';
 import CheckboxConfirmation from './components/ContentManagerHooks/ConfirmationCheckbox';
 

--- a/packages/core/admin/screens/Overview/index.tsx
+++ b/packages/core/admin/screens/Overview/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
-  ContentLayout, HeaderLayout, Typography, Grid, GridItem, Flex, Link, Box,
+  ContentLayout, HeaderLayout, Typography, Grid, GridItem, Flex, Link,
 } from '@strapi/design-system';
 import { ExternalLink } from '@strapi/icons';
 import { CheckPagePermissions, request } from '@strapi/helper-plugin';

--- a/packages/core/admin/screens/Overview/index.tsx
+++ b/packages/core/admin/screens/Overview/index.tsx
@@ -37,15 +37,6 @@ const List = () => {
         title={formatMessage({ id: 'webtools.settings.page.overview.title', defaultMessage: 'Overview' })}
         subtitle={formatMessage({ id: 'webtools.settings.page.overview.description', defaultMessage: 'Webtools global information' })}
         as="h2"
-        // TODO: Generate all button.
-        // primaryAction={(
-        //   <Button onClick={() => console.log('generate')} size="L">
-        //     {formatMessage({
-        //       id: 'webtools.settings.button.generate_paths',
-        //       defaultMessage: 'Generate paths',
-        //     })}
-        //   </Button>
-        // )}
       />
       <ContentLayout>
         <Flex direction="column" alignItems="stretch" gap={6}>
@@ -127,7 +118,7 @@ const List = () => {
             </Grid>
           </Flex>
         </Flex>
-        <Box
+        {/* <Box
           hasRadius
           background="neutral0"
           shadow="tableShadow"
@@ -155,7 +146,7 @@ const List = () => {
               <div>{addon.info.addonName}</div>
             ))}
           </Flex>
-        </Box>
+        </Box> */}
       </ContentLayout>
     </CheckPagePermissions>
   );

--- a/packages/core/admin/screens/Patterns/CreatePage/index.tsx
+++ b/packages/core/admin/screens/Patterns/CreatePage/index.tsx
@@ -32,12 +32,14 @@ import LabelField from '../../../components/LabelField';
 import PatternField from '../../../components/PatternField';
 import { PatternFormValues, ValidatePatternResponse } from '../../../types/url-patterns';
 import { EnabledContentTypes } from '../../../types/enabled-contenttypes';
+import LanguageCheckboxes from '../../../components/LanguageCheckboxes';
+import HiddenLocalizedField from '../../../components/HiddenLocalizedField';
 
 const CreatePattternPage = () => {
   const { push } = useHistory();
   const toggleNotification = useNotification();
   const [loading, setLoading] = useState(false);
-  const [contentTypes, setContentTypes] = useState([]);
+  const [contentTypes, setContentTypes] = useState<EnabledContentTypes>([]);
   const { formatMessage } = useIntl();
 
   useEffect(() => {
@@ -110,11 +112,19 @@ const CreatePattternPage = () => {
     );
   }
 
+  const getSelectedContentType = (uid: string) => {
+    const selectedContentType = contentTypes.filter(
+      (type) => type.uid === uid,
+    )[0];
+
+    return selectedContentType;
+  };
+
   return (
     <Formik<PatternFormValues>
       enableReinitialize
       initialValues={{
-        label: '', pattern: '', contenttype: '', languages: [],
+        label: '', pattern: '', contenttype: '', languages: [], localized: false,
       }}
       onSubmit={handleCreateSubmit}
       validationSchema={schema}
@@ -192,18 +202,37 @@ const CreatePattternPage = () => {
                     </GridItem>
                     <GridItem col={12} />
                     {(values.contenttype !== '') && (
-                    <GridItem col={6}>
-                      <PatternField
-                        values={values}
-                        uid={values.contenttype}
-                        setFieldValue={setFieldValue}
-                        error={
-                            errors.pattern && touched.pattern
-                              ? errors.pattern
-                              : null
-                          }
-                      />
-                    </GridItem>
+                      <GridItem col={6}>
+                        <PatternField
+                          values={values}
+                          uid={values.contenttype}
+                          setFieldValue={setFieldValue}
+                          error={
+                              errors.pattern && touched.pattern
+                                ? errors.pattern
+                                : null
+                            }
+                        />
+                      </GridItem>
+                    )}
+                    <HiddenLocalizedField
+                      localized={getSelectedContentType(values.contenttype)?.localized}
+                      setFieldValue={setFieldValue}
+                    />
+                    {values.localized && (
+                      <GridItem col={12}>
+                        <GridItem col={6}>
+                          <LanguageCheckboxes
+                            onChange={(newLanguages) => setFieldValue('languages', newLanguages)}
+                            selectedLanguages={values.languages}
+                            error={
+                              errors.languages && touched.languages
+                                ? errors.languages
+                                : null
+                            }
+                          />
+                        </GridItem>
+                      </GridItem>
                     )}
                   </Grid>
                 </Stack>

--- a/packages/core/admin/screens/Patterns/CreatePage/index.tsx
+++ b/packages/core/admin/screens/Patterns/CreatePage/index.tsx
@@ -64,7 +64,7 @@ const CreatePattternPage = () => {
       },
     })
       .then(() => {
-        push(`/settings/${pluginId}/patterns`);
+        push(`/plugins/${pluginId}/patterns`);
         toggleNotification({ type: 'success', message: { id: 'webtools.settings.success.create' } });
         setSubmitting(false);
       })
@@ -129,7 +129,7 @@ const CreatePattternPage = () => {
             subtitle={formatMessage({ id: 'webtools.settings.page.patterns.create.description', defaultMessage: 'Add a pattern for automatic URL alias generation.' })}
             as="h2"
             navigationAction={(
-              <Link startIcon={<ArrowLeft />} to={`/settings/${pluginId}/patterns`}>
+              <Link startIcon={<ArrowLeft />} to={`/plugins/${pluginId}/patterns`}>
                 {formatMessage({
                   id: 'global.back',
                   defaultMessage: 'Back',

--- a/packages/core/admin/screens/Patterns/CreatePage/utils/schema.ts
+++ b/packages/core/admin/screens/Patterns/CreatePage/utils/schema.ts
@@ -1,11 +1,15 @@
 import * as yup from 'yup';
 import { translatedErrors } from '@strapi/helper-plugin';
 
-const schema = yup.object().shape({
+const schema = () => yup.object().shape({
   label: yup.string().required(translatedErrors.required),
   pattern: yup.string().required(translatedErrors.required),
   contenttype: yup.string().required(translatedErrors.required),
-  // languages: yup.array().min(1, translatedErrors.required),
+  languages: yup.array().when('localized', {
+    is: true,
+    then: yup.array().min(1, 'Select at least one language'),
+    otherwise: yup.array().notRequired(),
+  }),
 });
 
 export default schema;

--- a/packages/core/admin/screens/Patterns/EditPage/index.tsx
+++ b/packages/core/admin/screens/Patterns/EditPage/index.tsx
@@ -38,7 +38,7 @@ const EditPatternPage = () => {
 
   const {
     params: { id },
-  } = useRouteMatch<{ id: string }>(`/settings/${pluginId}/patterns/:id`)!;
+  } = useRouteMatch<{ id: string }>(`/plugins/${pluginId}/patterns/:id`)!;
 
   useEffect(() => {
     setLoading(true);
@@ -77,7 +77,7 @@ const EditPatternPage = () => {
       },
     })
       .then(() => {
-        push(`/settings/${pluginId}/patterns`);
+        push(`/plugins/${pluginId}/patterns`);
         toggleNotification({
           type: 'success',
           message: { id: 'webtools.settings.success.edit' },
@@ -172,7 +172,7 @@ const EditPatternPage = () => {
             navigationAction={(
               <Link
                 startIcon={<ArrowLeft />}
-                to={`/settings/${pluginId}/patterns`}
+                to={`/plugins/${pluginId}/patterns`}
               >
                 {formatMessage({
                   id: 'global.back',

--- a/packages/core/admin/screens/Patterns/EditPage/index.tsx
+++ b/packages/core/admin/screens/Patterns/EditPage/index.tsx
@@ -27,13 +27,15 @@ import LabelField from '../../../components/LabelField';
 import PatternField from '../../../components/PatternField';
 import { PatternEntity, PatternFormValues, ValidatePatternResponse } from '../../../types/url-patterns';
 import { EnabledContentTypes } from '../../../types/enabled-contenttypes';
+import HiddenLocalizedField from '../../../components/HiddenLocalizedField';
+import LanguageCheckboxes from '../../../components/LanguageCheckboxes';
 
 const EditPatternPage = () => {
   const { push } = useHistory();
   const toggleNotification = useNotification();
   const [loading, setLoading] = useState(false);
   const [patternEntity, setPatternEntity] = useState<null | PatternEntity>(null);
-  const [contentTypes, setContentTypes] = useState([]);
+  const [contentTypes, setContentTypes] = useState<EnabledContentTypes>([]);
   const { formatMessage } = useIntl();
 
   const {
@@ -135,6 +137,14 @@ const EditPatternPage = () => {
     );
   }
 
+  const getSelectedContentType = (uid: string) => {
+    const selectedContentType = contentTypes.filter(
+      (type) => type.uid === uid,
+    )[0];
+
+    return selectedContentType;
+  };
+
   return (
     <Formik<PatternFormValues>
       enableReinitialize
@@ -144,6 +154,7 @@ const EditPatternPage = () => {
         contenttype: patternEntity.contenttype,
         languages: patternEntity.languages,
         code: patternEntity.code,
+        localized: false,
       }}
       onSubmit={handleEditSubmit}
       validationSchema={schema}
@@ -260,6 +271,25 @@ const EditPatternPage = () => {
                               : null
                           }
                         />
+                      </GridItem>
+                    )}
+                    <HiddenLocalizedField
+                      localized={getSelectedContentType(values.contenttype)?.localized}
+                      setFieldValue={setFieldValue}
+                    />
+                    {values.localized && (
+                      <GridItem col={12}>
+                        <GridItem col={6}>
+                          <LanguageCheckboxes
+                            onChange={(newLanguages) => setFieldValue('languages', newLanguages)}
+                            selectedLanguages={values.languages}
+                            error={
+                              errors.languages && touched.languages
+                                ? errors.languages
+                                : null
+                            }
+                          />
+                        </GridItem>
                       </GridItem>
                     )}
                   </Grid>

--- a/packages/core/admin/screens/Patterns/EditPage/utils/schema.ts
+++ b/packages/core/admin/screens/Patterns/EditPage/utils/schema.ts
@@ -5,7 +5,11 @@ const schema = yup.object().shape({
   label: yup.string().required(translatedErrors.required),
   pattern: yup.string().required(translatedErrors.required),
   contenttype: yup.string().required(translatedErrors.required),
-  // languages: yup.array().min(1, translatedErrors.required),
+  languages: yup.array().when('localized', {
+    is: true,
+    then: yup.array().min(1, 'Select at least one language'),
+    otherwise: yup.array().notRequired(),
+  }),
 });
 
 export default schema;

--- a/packages/core/admin/screens/Patterns/ListPage/components/TableBody/index.tsx
+++ b/packages/core/admin/screens/Patterns/ListPage/components/TableBody/index.tsx
@@ -37,7 +37,7 @@ const TableBody: React.FC<Props> = ({ patterns }) => {
   };
 
   const handleClickEdit = (id: number) => {
-    push(`/settings/${pluginId}/patterns/${id}`);
+    push(`/plugins/${pluginId}/patterns/${id}`);
   };
 
   return (

--- a/packages/core/admin/screens/Patterns/ListPage/index.tsx
+++ b/packages/core/admin/screens/Patterns/ListPage/index.tsx
@@ -50,7 +50,7 @@ const ListPatternPage = () => {
         subtitle={formatMessage({ id: 'webtools.settings.page.patterns.description', defaultMessage: 'A list of all the known URL alias patterns.' })}
         as="h2"
         primaryAction={(
-          <Button onClick={() => push(`/settings/${pluginId}/patterns/new`)} startIcon={<Plus />} size="L">
+          <Button onClick={() => push(`/plugins/${pluginId}/patterns/new`)} startIcon={<Plus />} size="L">
             {formatMessage({
               id: 'webtools.settings.button.add_pattern',
               defaultMessage: 'Add new pattern',

--- a/packages/core/admin/screens/Patterns/index.tsx
+++ b/packages/core/admin/screens/Patterns/index.tsx
@@ -11,12 +11,12 @@ const Patterns = () => (
   <CheckPagePermissions permissions={pluginPermissions['settings.patterns']}>
     <Switch>
       <Route
-        path={`/settings/${pluginId}/patterns/new`}
+        path={`/plugins/${pluginId}/patterns/new`}
         component={PatternsCreatePage}
         exact
       />
-      <Route path={`/settings/${pluginId}/patterns/:id`} component={PatternsEditPage} exact />
-      <Route path={`/settings/${pluginId}/patterns`} component={PatternsListPage} exact />
+      <Route path={`/plugins/${pluginId}/patterns/:id`} component={PatternsEditPage} exact />
+      <Route path={`/plugins/${pluginId}/patterns`} component={PatternsListPage} exact />
       {/* <Route path="" component={NotFound} /> */}
     </Switch>
   </CheckPagePermissions>

--- a/packages/core/admin/types/languages.ts
+++ b/packages/core/admin/types/languages.ts
@@ -1,7 +1,6 @@
 export interface EnabledContentType {
   name: string,
   uid: string,
-  localized: boolean,
 }
 
 export type EnabledContentTypes = EnabledContentType[];

--- a/packages/core/admin/types/url-aliases.ts
+++ b/packages/core/admin/types/url-aliases.ts
@@ -3,4 +3,5 @@ export interface UrlAliasEntity {
   url_path: string
   contenttype: string
   generated: boolean
+  locale?: string
 }

--- a/packages/core/admin/types/url-patterns.ts
+++ b/packages/core/admin/types/url-patterns.ts
@@ -14,6 +14,7 @@ export interface PatternFormValues {
   pattern: string,
   contenttype: string,
   languages: any[],
+  localized: boolean,
   code?: string,
 }
 

--- a/packages/core/server/admin-api/content-types/url-alias/schema.json
+++ b/packages/core/server/admin-api/content-types/url-alias/schema.json
@@ -16,6 +16,9 @@
     },
     "content-type-builder": {
       "visible": false
+    },
+    "i18n": {
+      "localized": true
     }
   },
   "attributes": {

--- a/packages/core/server/admin-api/controllers/info.ts
+++ b/packages/core/server/admin-api/controllers/info.ts
@@ -15,6 +15,7 @@ export default {
     const contentTypes: {
       name: string;
       uid: string;
+      localized: boolean;
     }[] = [];
 
     Object.values(strapi.contentTypes).forEach((contentType: Schema.ContentType) => {
@@ -25,10 +26,15 @@ export default {
         'webtools',
         'enabled',
       ]) as boolean;
+      const isLocalized = _.get(pluginOptions, [
+        'i18n',
+        'localized',
+      ]) as boolean;
       if (isInContentManager === true) {
         contentTypes.push({
           name: contentType.globalId,
           uid: contentType.uid,
+          localized: isLocalized || false,
         });
       }
     });

--- a/packages/core/server/admin-api/controllers/url-alias.ts
+++ b/packages/core/server/admin-api/controllers/url-alias.ts
@@ -2,12 +2,10 @@
 
 import { Context } from 'koa';
 import { EntityService } from '@strapi/strapi';
-import { Common } from '@strapi/types';
 import { errors } from '@strapi/utils';
 
 import { getPluginService } from '../../util/getPluginService';
 import { KoaContext } from '../../types/koa';
-import { GenerationType } from '../../types';
 import { GenerateParams } from '../services/bulk-generate';
 
 

--- a/packages/core/server/admin-api/controllers/url-alias.ts
+++ b/packages/core/server/admin-api/controllers/url-alias.ts
@@ -8,8 +8,8 @@ import { errors } from '@strapi/utils';
 import { getPluginService } from '../../util/getPluginService';
 import { KoaContext } from '../../types/koa';
 import { GenerationType } from '../../types';
+import { GenerateParams } from '../services/bulk-generate';
 
-interface GenerateParams { types: Common.UID.ContentType[], generationType: GenerationType }
 
 /**
  * Path controller
@@ -66,7 +66,6 @@ export default {
     ctx: KoaContext<GenerateParams>,
   ) => {
     const { types, generationType } = ctx.request.body;
-    let generatedCount = 0;
 
     // Validation
     if (!types || !generationType) {
@@ -78,59 +77,11 @@ export default {
       throw new errors.ValidationError('Missing required POST parameter(s)', details);
     }
 
-    // Map over all the types sent in the request.
-    await Promise.all(types.map(async (type) => {
-      if (generationType === 'all') {
-        // Delete all the URL aliases for the given type.
-        await getPluginService('url-alias').deleteMany({
-          filters: {
-            contenttype: type,
-          },
-        });
-      }
+    const generatedCount = await getPluginService('bulkGenerate').generateUrlAliases({ types, generationType });
 
-      if (generationType === 'only_generated') {
-        // Delete all the auto generated URL aliases of the given type.
-        await getPluginService('url-alias').deleteMany({
-          filters: {
-            contenttype: type,
-            generated: true,
-          },
-        });
-      }
-
-      const urlPattern = await getPluginService('urlPatternService').findByUid(type);
-      const relations = getPluginService('urlPatternService').getRelationsFromPattern(urlPattern);
-
-      // Query all the entities of the type that do not have a corresponding URL alias.
-      const entities = await strapi.entityService.findMany(type, {
-        filters: {
-          url_alias: null,
-        },
-        populate: {
-          ...relations.reduce((obj, key) => ({ ...obj, [key]: {} }), {}),
-        },
-      });
-
-      // For all those entities we will create a URL alias and connect it to the entity.
-      await Promise.all(entities.map(async (entity) => {
-        const generatedPath = getPluginService('urlPatternService').resolvePattern(type, entity, urlPattern);
-        const newUrlAlias = await getPluginService('urlAliasService').create({
-          url_path: generatedPath,
-          generated: true,
-          contenttype: type,
-        });
-
-        await strapi.entityService.update(type, entity.id, {
-          data: {
-            // @ts-ignore
-            url_alias: newUrlAlias.id,
-          },
-        });
-
-        generatedCount += 1;
-      }));
-    }));
+    if (strapi.plugin('i18n')) {
+      await getPluginService('bulkGenerate').createLanguageLinksForUrlAliases();
+    }
 
     // Return the amount of generated URL aliases.
     ctx.body = {

--- a/packages/core/server/admin-api/register.ts
+++ b/packages/core/server/admin-api/register.ts
@@ -31,11 +31,6 @@ export default (strapi: IStrapi) => {
         relation: 'oneToOne',
         target: 'plugin::webtools.url-alias',
         unique: true,
-        pluginOptions: {
-          i18n: {
-            localized: true,
-          },
-        },
       });
     }
   });

--- a/packages/core/server/admin-api/services/bulk-generate.ts
+++ b/packages/core/server/admin-api/services/bulk-generate.ts
@@ -1,0 +1,159 @@
+import { Common } from '@strapi/types';
+import { getPluginService } from '../../util/getPluginService';
+import { GenerationType } from '../../types';
+
+export interface GenerateParams { types: Common.UID.ContentType[], generationType: GenerationType }
+
+/**
+ * Find related entity.
+ *
+ * @param {object} data the data.
+ * @returns {void}
+ */
+const createLanguageLinksForUrlAliases = async () => {
+  const urlAliases = await getPluginService('urlAliasService').findMany(true, {
+    // @ts-ignore
+    fields: ['id', 'contenttype', 'locale'],
+  });
+
+  await Promise.all(urlAliases.results.map(async (urlAlias) => {
+    const relatedEntity = await getPluginService('urlAliasService').findRelatedEntity(urlAlias, {
+      fields: [],
+      populate: {
+        // @ts-ignore
+        localizations: {
+          populate: {
+            url_alias: {
+              fields: ['id'],
+            },
+          },
+        },
+      },
+    });
+
+    if (!relatedEntity) {
+      return;
+    }
+
+    // @ts-ignore
+    const localizations = relatedEntity.localizations as Array<{
+      url_alias: {
+        id: number
+      },
+    }>;
+
+
+    const urlAliasLocalizations = localizations
+      ?.map((loc) => loc.url_alias?.id)
+      ?.filter((loc) => loc) || [];
+
+    /**
+     * @todo
+     * Call the Strapi entity service, instead of the db query.
+     * Currently we can't because saving the localizations is not working.
+     * Eventough the localizations are present at the moment of updating.
+     */
+    // eslint-disable-next-line no-await-in-loop, @typescript-eslint/no-unsafe-assignment
+    await strapi.db.query('plugin::webtools.url-alias').update({
+      where: {
+        id: urlAlias.id,
+      },
+      data: {
+        localizations: urlAliasLocalizations,
+      },
+    });
+  }));
+};
+
+/**
+ * generateUrlAliases.
+ *
+ * @param {number} id the id.
+ * @returns {number} - the total amount generated URLs.
+ */
+const generateUrlAliases = async (parms: GenerateParams) => {
+  const { types, generationType } = parms;
+  let generatedCount = 0;
+
+  // Map over all the types sent in the request.
+  await Promise.all(types.map(async (type) => {
+    if (generationType === 'all') {
+      // Delete all the URL aliases for the given type.
+      await getPluginService('url-alias').deleteMany({
+        // @ts-ignore
+        locale: 'all',
+        filters: {
+          contenttype: type,
+        },
+      });
+    }
+
+    if (generationType === 'only_generated') {
+      // Delete all the auto generated URL aliases of the given type.
+      await getPluginService('url-alias').deleteMany({
+        // @ts-ignore
+        locale: 'all',
+        filters: {
+          contenttype: type,
+          generated: true,
+        },
+      });
+    }
+
+    const urlPattern = await getPluginService('urlPatternService').findByUid(type);
+    const relations = getPluginService('urlPatternService').getRelationsFromPattern(urlPattern);
+
+    // Query all the entities of the type that do not have a corresponding URL alias.
+    const entities = await strapi.entityService.findMany(type, {
+      filters: {
+        url_alias: null,
+      },
+      locale: 'all',
+      // @ts-ignore
+      populate: {
+        ...relations.reduce((obj, key) => ({ ...obj, [key]: {} }), {}),
+      },
+    });
+
+    /**
+     * @todo
+     * We should do a Promise.all(entities.map()) here to speed up the process.
+     * Using that method we can create all the URL aliases in parallel.
+     * Currently this is not possible due to the duplicateCheck function.
+     * Race conditions can occur when two entities have the same URL path.
+     */
+    // For all those entities we will create a URL alias and connect it to the entity.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const entity of entities) {
+      const generatedPath = getPluginService('urlPatternService').resolvePattern(type, entity, urlPattern);
+
+      // eslint-disable-next-line no-await-in-loop
+      const newUrlAlias = await getPluginService('urlAliasService').create({
+        url_path: generatedPath,
+        generated: true,
+        contenttype: type,
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        locale: entity.locale,
+      });
+
+      // eslint-disable-next-line no-await-in-loop
+      await strapi.entityService.update(type, entity.id, {
+        data: {
+          // @ts-ignore
+          url_alias: newUrlAlias.id,
+        },
+      });
+
+      generatedCount += 1;
+    }
+  }));
+
+  return generatedCount;
+};
+
+
+export default () => ({
+  generateUrlAliases,
+  createLanguageLinksForUrlAliases,
+});

--- a/packages/core/server/admin-api/services/query-layer-decorator.ts
+++ b/packages/core/server/admin-api/services/query-layer-decorator.ts
@@ -136,7 +136,7 @@ const decorator = (service: IDecoratedService) => ({
 
     // Fetch the URL alias localizations.
     const urlAliasLocalizations = entity.localizations
-      ?.map((loc) => loc.url_alias.id)
+      ?.map((loc) => loc.url_alias?.id)
       ?.filter((loc) => loc) || [];
 
     const entityWithoutLocalizations = {

--- a/packages/core/server/admin-api/services/url-alias.ts
+++ b/packages/core/server/admin-api/services/url-alias.ts
@@ -72,6 +72,7 @@ const findMany = async (showDrafts: boolean = false, query: EntityService.Params
 
   const { results, pagination } = await strapi.entityService.findPage('plugin::webtools.url-alias', {
     ...query,
+    locale: 'all',
     filters: {
       ...query?.filters,
       published_at: excludeDrafts ? {

--- a/packages/core/server/admin-api/services/url-alias.ts
+++ b/packages/core/server/admin-api/services/url-alias.ts
@@ -1,6 +1,6 @@
 
 
-import { EntityService, Entity } from '@strapi/types';
+import { EntityService, Entity, Common } from '@strapi/types';
 import { getPluginService } from '../../util/getPluginService';
 
 /**
@@ -39,6 +39,29 @@ const create = async (data: EntityService.Params.Pick<'plugin::webtools.url-alia
   });
 
   return pathEntity;
+};
+
+/**
+ * Find related entity.
+ *
+ * @param {object} data the data.
+ * @returns {void}
+ */
+const findRelatedEntity = async (urlAlias: EntityService.GetValues<'plugin::webtools.url-alias'>, query: EntityService.Params.Pick<Common.UID.ContentType, 'fields' | 'populate' | 'sort' | 'filters' | '_q' | 'publicationState' | 'plugin'> = {}) => {
+  const type = urlAlias.contenttype as Common.UID.ContentType;
+  const entity = await strapi.entityService.findMany(type, {
+    locale: 'all',
+    ...query,
+    filters: {
+      ...query?.filters,
+      // @ts-ignore
+      url_alias: urlAlias.id,
+    },
+  });
+
+  if (!entity[0]) return null;
+
+  return entity[0];
 };
 
 /**
@@ -140,5 +163,6 @@ export default () => ({
   findOne,
   findMany,
   findByPath,
+  findRelatedEntity,
   delete: deleteUrlAlias,
 });

--- a/packages/core/server/admin-api/services/url-pattern.ts
+++ b/packages/core/server/admin-api/services/url-pattern.ts
@@ -46,14 +46,19 @@ export default () => ({
    * FindByUid.
    *
    * @param {string} uid the uid.
+   * @param {string} langcode the langcode.
    */
-  findByUid: async (uid: string): Promise<string> => {
-    const patterns = await getPluginService('urlPatternService').findMany({
+  findByUid: async (uid: string, langcode?: string): Promise<string> => {
+    let patterns = await getPluginService('urlPatternService').findMany({
       filters: {
         contenttype: uid,
       },
-      limit: 1,
     });
+
+    if (langcode) {
+      patterns = patterns
+        .filter((pattern) => (pattern.languages as string).includes(langcode));
+    }
 
     if (!patterns[0]) {
       return strapi.config.get('plugin.webtools.default_pattern');

--- a/packages/core/server/index.ts
+++ b/packages/core/server/index.ts
@@ -13,6 +13,7 @@ import adminApiUrlPatternController from './admin-api/controllers/url-pattern';
 import adminApiInfoController from './admin-api/controllers/info';
 import adminApiUrlAliasService from './admin-api/services/url-alias';
 import adminApiUrlPatternService from './admin-api/services/url-pattern';
+import adminApiBulkGenerateService from './admin-api/services/bulk-generate';
 import adminApiUrlAliasRoutes from './admin-api/routes/url-alias';
 import adminApiUrlPatternRoutes from './admin-api/routes/url-pattern';
 import adminApiInfoRoutes from './admin-api/routes/info';
@@ -75,5 +76,6 @@ export default {
     urlPatternService: adminApiUrlPatternService,
     byPathService: contentApiByPathService,
     queryLayerDecorator: queryLayerDecoratorService,
+    bulkGenerate: adminApiBulkGenerateService,
   },
 };

--- a/packages/core/server/types/strapi.ts
+++ b/packages/core/server/types/strapi.ts
@@ -20,10 +20,30 @@ export interface IStrapi extends Omit<Strapi, 'entityService' | 'admin'> {
 
 export interface IDecoratedService {
   create: {
-    call: (context: any, uid: any, options: any) => Promise<{ id: number }>
+    call: (context: any, uid: any, options: any) => Promise<{
+      id: number,
+      locale?: string,
+      localizations?: [
+        {
+          url_alias: {
+            id: number
+          },
+        },
+      ],
+    }>
   },
   update: {
-    call: (context: any, uid: any, id: any, options: any) => Promise<{ id: number }>
+    call: (context: any, uid: any, id: any, options: any) => Promise<{
+      id: number
+      locale?: string,
+      localizations?: [
+        {
+          url_alias: {
+            id: number
+          },
+        },
+      ],
+    }>
   },
   delete: {
     call: (context: any, uid: any, options: any) => Promise<{ id: number }>
@@ -37,4 +57,13 @@ export interface IDecoratedService {
 
 export interface IDecoratedServiceOptions<Fields> {
   data: Fields
+  populate: {
+    localizations: {
+      populate: {
+        url_alias: {
+          fields: ['id']
+        }
+      }
+    }
+  }
 }

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -70,7 +70,7 @@ module.exports = {
           label: 'Test API pattern',
           code: 'test_api_pattern',
           contenttype: 'api::test.test',
-          languages: [],
+          languages: ['en'],
         }
       });
 

--- a/playground/types/generated/contentTypes.d.ts
+++ b/playground/types/generated/contentTypes.d.ts
@@ -601,6 +601,9 @@ export interface PluginWebtoolsUrlAlias extends Schema.CollectionType {
     'content-type-builder': {
       visible: false;
     };
+    i18n: {
+      localized: true;
+    };
   };
   attributes: {
     url_path: Attribute.String & Attribute.Required & Attribute.Unique;
@@ -620,6 +623,12 @@ export interface PluginWebtoolsUrlAlias extends Schema.CollectionType {
       'admin::user'
     > &
       Attribute.Private;
+    localizations: Attribute.Relation<
+      'plugin::webtools.url-alias',
+      'oneToMany',
+      'plugin::webtools.url-alias'
+    >;
+    locale: Attribute.String;
   };
 }
 
@@ -906,12 +915,7 @@ export interface ApiCategoryCategory extends Schema.CollectionType {
       'oneToOne',
       'plugin::webtools.url-alias'
     > &
-      Attribute.Unique &
-      Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+      Attribute.Unique;
   };
 }
 
@@ -959,12 +963,7 @@ export interface ApiPrivateCategoryPrivateCategory
       'oneToOne',
       'plugin::webtools.url-alias'
     > &
-      Attribute.Unique &
-      Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+      Attribute.Unique;
   };
 }
 
@@ -1015,12 +1014,7 @@ export interface ApiTestTest extends Schema.CollectionType {
       'oneToOne',
       'plugin::webtools.url-alias'
     > &
-      Attribute.Unique &
-      Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+      Attribute.Unique;
     localizations: Attribute.Relation<
       'api::test.test',
       'oneToMany',


### PR DESCRIPTION
### What does it do?

This PR implements internationalization for webtools. Allowing you to translate URL aliases and setup patterns for specific languages.

### Why is it needed?

To allow people to use Webtools for multilingual websites with multilingual URLs.

### How to test it?

**Setup**
1. Pull the branch of this PR
2. Follow the [contribution guidelines](https://github.com/pluginpal/strapi-webtools/blob/master/CONTRIBUTING.md) to spin up the project.
3. Enable internationalization for a content-type. Create an entry of that content type. Translate that entry. Use the "copy from other language" button.
4. Create two different URL patterns for the content type, each with a different language.

**Test steps**

- [x] Go to `/api/webtools/url-alias?populate=*`, you should now see the localizations of the URL aliases
- [x] Use the "Bulk generate" button in the admin panel to regenerate all URLs. Double check if the localizations links are created correctly by going to `/api/webtools/url-alias?populate=*` again.
- [x] Check that the correct patterns are being used to generate the URLs. 
- [ ] Disable the `i18n` plugin and check that all core functionalities of webtools are still working properly. (pattern creation, url alias generation, router endpoint etc) 

### Related issue(s)/PR(s)

#30 
