### PR TITLE
feat: remove !pattern.length for loading state

### DIFF
--- a/.changeset/cuddly-clouds-sneeze.md
+++ b/.changeset/cuddly-clouds-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@pluginpal/webtools-core": minor
+---
+
+Fix issue with not loading url patterns when there is an empty array

--- a/packages/core/admin/screens/Patterns/ListPage/index.tsx
+++ b/packages/core/admin/screens/Patterns/ListPage/index.tsx
@@ -42,7 +42,7 @@ const ListPatternPage = () => {
     });
   }, [fetchClient]);
 
-  if (loading || !patterns.length) {
+  if (loading) {
     return (
       <Center>
         <Loader>{formatMessage({ id: 'webtools.settings.loading', defaultMessage: 'Loading content...' })}</Loader>


### PR DESCRIPTION
### What does it do?

Fix issue with not loading url patterns in bug report:  [issue-150](https://github.com/pluginpal/strapi-webtools/issues/150)

