### PR TITLE
fix: check if a hostname is present before building the sitemap stream

### DIFF
--- a/.changeset/olive-flowers-nail.md
+++ b/.changeset/olive-flowers-nail.md
@@ -1,0 +1,5 @@
+---
+"@pluginpal/webtools-addon-sitemap": patch
+---
+
+Check if a hostname is present before building the sitemap stream

--- a/packages/addons/sitemap/server/services/core.js
+++ b/packages/addons/sitemap/server/services/core.js
@@ -8,7 +8,7 @@ import { getConfigUrls } from '@strapi/utils';
 import { SitemapStream, streamToPromise, SitemapAndIndexStream } from 'sitemap';
 import { isEmpty } from 'lodash';
 
-import { logMessage, getService } from '../utils';
+import { logMessage, getService, isValidUrl } from '../utils';
 
 /**
  * Add link x-default url to url bundles from strapi i18n plugin default locale.
@@ -280,9 +280,20 @@ const getSitemapStream = async (urlCount) => {
  */
 const createSitemap = async () => {
   const sitemapEntries = await getService('core').createSitemapEntries();
+  const config = await getService('settings').getConfig();
 
   if (isEmpty(sitemapEntries)) {
-    strapi.log.info(logMessage('No sitemap XML was generated because there were 0 URLs configured.'));
+    strapi.log.warn(logMessage('No sitemap XML was generated because there were 0 URLs configured.'));
+    return;
+  }
+
+  if (!config.hostname) {
+    strapi.log.warn(logMessage('No sitemap XML was generated because there was no hostname configured.'));
+    return;
+  }
+
+  if (!isValidUrl(config.hostname)) {
+    strapi.log.warn(logMessage('No sitemap XML was generated because the hostname was invalid'));
     return;
   }
 

--- a/packages/addons/sitemap/server/utils/index.js
+++ b/packages/addons/sitemap/server/utils/index.js
@@ -30,3 +30,13 @@ export const noLimit = async (strapi, queryString, parameters, limit = 5000) => 
 
   return entries;
 };
+
+export const isValidUrl = (url) => {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Backported this fix from the standalone sitemap plugin: https://github.com/pluginpal/strapi-plugin-sitemap/pull/178

### Why is it needed?

Because the webtools sitemap addon will replace the standalone plugin.
