### PR TITLE
fix: issue with sitemap generation when using the x-default setting (…

### DIFF
--- a/.changeset/bright-news-build.md
+++ b/.changeset/bright-news-build.md
@@ -1,0 +1,5 @@
+---
+"@pluginpal/webtools-addon-sitemap": patch
+---
+
+Fix issue with sitemap generation when using the x-default setting

--- a/packages/addons/sitemap/server/services/core.js
+++ b/packages/addons/sitemap/server/services/core.js
@@ -283,8 +283,6 @@ const getSitemapStream = async (urlCount) => {
 const createSitemap = async () => {
   const sitemapEntries = await getService('core').createSitemapEntries();
 
-  console.log(sitemapEntries);
-
   const config = await getService('settings').getConfig();
 
   if (isEmpty(sitemapEntries)) {


### PR DESCRIPTION
…i18n)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

I've changed the `getDefaultLanguageLink` service from being async to being a synchronous function.
This was possible by fetching the default language from the db earlier in de code tree, and passing down it's value to the nested functions.

### Why is it needed?

To solve issue #158 

### How to test it?

1. Create a content type
2. Enable localization for the content type
3. Create a couple entries
4. Translate the entries
5. Add the content type to the sitemap settings using URL bundles
6. Explicitly set the x-default setting to be something other then disabled.
7. Generate the sitemap

Test that prior to this PR the following steps would cause an error, and after this PR the following steps work as expected.

### Related issue(s)/PR(s)

#158 