### PR TITLE
Fix incorrect "modified" status

### DIFF
--- a/.changeset/dark-items-bet.md
+++ b/.changeset/dark-items-bet.md
@@ -1,0 +1,5 @@
+---
+"strapi-plugin-webtools": patch
+---
+
+fix: incorrect 'modified' status by preventing the updated_at value to be changed when linking the url_alias relation

--- a/packages/core/server/middlewares/generate-url-alias.ts
+++ b/packages/core/server/middlewares/generate-url-alias.ts
@@ -141,14 +141,9 @@ const generateUrlAliasMiddleware: Modules.Documents.Middleware.Middleware = asyn
   });
 
   await Promise.all(all.map(async (doc) => {
-    await strapi.db.query(uid as 'api::test.test').update({
-      where: {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        id: doc.id as string,
-      },
-      data: {
-        url_alias: [urlAliasEntity?.id],
-      },
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    await strapi.db.query(uid as 'api::test.test').updateRelations(doc.id as string, {
+      url_alias: [urlAliasEntity?.id],
     });
   }));
 


### PR DESCRIPTION
The status that is shown in the Strapi content manager had a bug.
Whilst using Webtools the status would never show "modified" even though the draft would have changes.
Reason for that being is that that "modified" status will be calculated by checking if the `updated_at` values of the draft & published versions are the same. Only if they are not the same, the status "modified" will be shown.

Now for Webtools; an update query will be ran for all entities of the document to link them to the url_alias. That will cause the `updated_at` value to increase. To prevent this the PR changes the `update` query to a `updateRelations` query. In this specific case they serve the same purpose, but the latter does not increase the `updated_at` value, preventing this issue.

Addresses #236 