### PR TITLE
fix: simplify scripts by adding devDependencies

### DIFF
--- a/.changeset/ten-times-shake.md
+++ b/.changeset/ten-times-shake.md
@@ -1,0 +1,7 @@
+---
+"webtools-addon-sitemap": patch
+"strapi-plugin-webtools": patch
+"webtools-cli": patch
+---
+
+fix: simplify scripts by adding devDependencies

--- a/packages/addons/sitemap/package.json
+++ b/packages/addons/sitemap/package.json
@@ -36,12 +36,12 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "../../../node_modules/.bin/pack-up build && ../../../node_modules/.bin/yalc push --publish",
-    "watch": "../../../node_modules/.bin/pack-up watch",
-    "watch:link": "../../../node_modules/.bin/strapi-plugin watch:link",
+    "build": "pack-up build && yalc push --publish",
+    "watch": "pack-up watch",
+    "watch:link": "strapi-plugin watch:link",
     "develop:copy-files": "copyfiles -u 1 xsl/**/* ../../../playground/src/plugins/webtools-addon-sitemap/xsl/",
-    "eslint": "../../../node_modules/.bin/eslint --max-warnings=0 './**/*.{js,jsx,ts,tsx}'",
-    "eslint:fix": "../../../node_modules/.bin/eslint --fix './**/*.{js,jsx,ts,tsx}'"
+    "eslint": "eslint --max-warnings=0 './**/*.{js,jsx,ts,tsx}'",
+    "eslint:fix": "eslint --fix './**/*.{js,jsx,ts,tsx}'"
   },
   "peerDependencies": {
     "@strapi/design-system": "^2.0.0-rc",
@@ -58,15 +58,18 @@
   "devDependencies": {
     "@strapi/design-system": "^2.0.0-rc",
     "@strapi/icons": "^2.0.0-rc",
+    "@strapi/pack-up": "^5.0.0",
     "@strapi/sdk-plugin": "^5.0.0",
     "@strapi/strapi": "^5.0.0",
     "@strapi/utils": "^5.0.0",
     "@types/lodash": "^4",
     "copyfiles": "^2.4.1",
+    "eslint": "^8.57.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6",
-    "styled-components": "^6"
+    "styled-components": "^6",
+    "yalc": "^1.0.0-pre.53"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,10 +19,10 @@
   ],
   "scripts": {
     "check": "pack-up check",
-    "build": "pack-up build && ../../node_modules/.bin/yalc push --publish",
+    "build": "pack-up build && yalc push --publish",
     "watch": "pack-up watch",
-    "eslint": "../../node_modules/.bin/eslint --max-warnings=0 './**/*.{js,jsx,ts,tsx}'",
-    "eslint:fix": "../../node_modules/.bin/eslint --fix './**/*.{js,jsx,ts,tsx}'"
+    "eslint": "eslint --max-warnings=0 './**/*.{js,jsx,ts,tsx}'",
+    "eslint:fix": "eslint --fix './**/*.{js,jsx,ts,tsx}'"
   },
   "bin": {
     "strapi-webtools": "./dist/index.js"
@@ -39,7 +39,9 @@
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.1.0",
     "@types/node": "^20.11.19",
-    "typescript": "^5.3.3"
+    "eslint": "^8.57.1",
+    "typescript": "^5.3.3",
+    "yalc": "^1.0.0-pre.53"
   },
   "author": {
     "name": "Boaz Poolman",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,9 +35,9 @@
   "scripts": {
     "build": "pack-up build && yalc push --publish",
     "watch": "pack-up watch",
-    "watch:link": "../../node_modules/.bin/strapi-plugin watch:link",
-    "eslint": "../../node_modules/.bin/eslint --max-warnings=0 './**/*.{js,jsx,ts,tsx}'",
-    "eslint:fix": "../../node_modules/.bin/eslint --fix './**/*.{js,jsx,ts,tsx}'"
+    "watch:link": "strapi-plugin watch:link",
+    "eslint": "eslint --max-warnings=0 './**/*.{js,jsx,ts,tsx}'",
+    "eslint:fix": "eslint --fix './**/*.{js,jsx,ts,tsx}'"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
@@ -62,10 +62,12 @@
     "@types/lodash": "^4",
     "@types/qs": "^6",
     "@types/react-copy-to-clipboard": "^5.0.7",
+    "eslint": "^8.57.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
-    "styled-components": "^6.0.0"
+    "styled-components": "^6.0.0",
+    "yalc": "^1.0.0-pre.53"
   },
   "dependencies": {
     "formik": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15754,7 +15754,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.0.0":
+"eslint@npm:^8.0.0, eslint@npm:^8.57.1":
   version: 8.57.1
   resolution: "eslint@npm:8.57.1"
   dependencies:
@@ -27886,6 +27886,7 @@ __metadata:
     "@types/lodash": "npm:^4"
     "@types/qs": "npm:^6"
     "@types/react-copy-to-clipboard": "npm:^5.0.7"
+    eslint: "npm:^8.57.1"
     formik: "npm:^2.4.0"
     lodash: "npm:^4.17.21"
     qs: "npm:^6.14.0"
@@ -27896,6 +27897,7 @@ __metadata:
     react-query: "npm:^3.39.3"
     react-router-dom: "npm:^6.0.0"
     styled-components: "npm:^6.0.0"
+    yalc: "npm:^1.0.0-pre.53"
     yup: "npm:^0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0
@@ -30382,6 +30384,7 @@ __metadata:
   dependencies:
     "@strapi/design-system": "npm:^2.0.0-rc"
     "@strapi/icons": "npm:^2.0.0-rc"
+    "@strapi/pack-up": "npm:^5.0.0"
     "@strapi/sdk-plugin": "npm:^5.0.0"
     "@strapi/strapi": "npm:^5.0.0"
     "@strapi/utils": "npm:^5.0.0"
@@ -30389,6 +30392,7 @@ __metadata:
     chalk: "npm:^4.1.2"
     commander: "npm:^8.3.0"
     copyfiles: "npm:^2.4.1"
+    eslint: "npm:^8.57.1"
     immutable: "npm:^3.8.2"
     lodash: "npm:^4.17.21"
     react: "npm:^18.0.0"
@@ -30401,6 +30405,7 @@ __metadata:
     sitemap: "npm:^7.1.0"
     styled-components: "npm:^6"
     xml2js: "npm:^0.5.0"
+    yalc: "npm:^1.0.0-pre.53"
   peerDependencies:
     "@strapi/design-system": ^2.0.0-rc
     "@strapi/icons": ^2.0.0-rc
@@ -30428,9 +30433,11 @@ __metadata:
     "@types/node": "npm:^20.11.19"
     chalk: "npm:^4.1.2"
     commander: "npm:^11.1.0"
+    eslint: "npm:^8.57.1"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
     typescript: "npm:^5.3.3"
+    yalc: "npm:^1.0.0-pre.53"
   bin:
     strapi-webtools: ./dist/index.js
   languageName: unknown


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Makes `yarn develop` in the root directory work (on my machine) by using the same commands in `webtools-addon-sitemap` as in the other packages.

### Why is it needed?

To develop this plugin.

### How to test it?

Run `yarn develop`.

Before:

```
PS C:\Projects\GitHub\strapi-webtools> yarn develop
turbo 2.5.0

 WARNING  stale pid file at "C:\\Users\\Jorrit\\AppData\\Local\\Temp\\turbod\\ce4c85f987b81795\\turbod.pid"
• Packages in scope: docs, strapi-plugin-webtools, webtools-addon-sitemap, webtools-cli
• Running watch:link in 4 packages
• Remote caching disabled
strapi-plugin-webtools:watch:link: cache bypass, force executing 115673eb70ec7dc4
webtools-addon-sitemap:watch:link: cache bypass, force executing 9bcb1035dcb66c21
strapi-plugin-webtools:watch:link: [INFO] Watching ./dist for changes to files with extensions: ts,js,png,svg,gif,jpeg,css
strapi-plugin-webtools:watch:link: 
strapi-plugin-webtools:watch:link: To use this package in Strapi, in a separate shell run:
strapi-plugin-webtools:watch:link: cd /path/to/strapi/project
strapi-plugin-webtools:watch:link:
strapi-plugin-webtools:watch:link: Then run one of the commands below based on the package manager used in that project:
strapi-plugin-webtools:watch:link:
strapi-plugin-webtools:watch:link: ## yarn
strapi-plugin-webtools:watch:link: yarn dlx yalc add --link strapi-plugin-webtools && yarn install
strapi-plugin-webtools:watch:link:
strapi-plugin-webtools:watch:link: ## npm
strapi-plugin-webtools:watch:link: npx yalc add strapi-plugin-webtools && npx yalc link strapi-plugin-webtools && npm install
webtools-addon-sitemap:watch:link: [INFO] Watching ./dist for changes to files with extensions: ts,js,png,svg,gif,jpeg,css
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: To use this package in Strapi, in a separate shell run:
webtools-addon-sitemap:watch:link: cd /path/to/strapi/project
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: Then run one of the commands below based on the package manager used in that project:
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: ## yarn
webtools-addon-sitemap:watch:link: yarn dlx yalc add --link webtools-addon-sitemap && yarn install
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: ## npm
webtools-addon-sitemap:watch:link: npx yalc add webtools-addon-sitemap && npx yalc link webtools-addon-sitemap && npm install
strapi-plugin-webtools:watch:link: (node:44016) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
strapi-plugin-webtools:watch:link: (Use `node --trace-deprecation ...` to show where the warning was created)
webtools-addon-sitemap:watch:link: (node:2104) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
webtools-addon-sitemap:watch:link: (Use `node --trace-deprecation ...` to show where the warning was created)
strapi-plugin-webtools:watch:link: Package content has not changed, skipping publishing.
webtools-addon-sitemap:watch:link: webtools-addon-sitemap@1.2.1 published in store.
webtools-addon-sitemap:watch:link: [0] 
webtools-addon-sitemap:watch:link: [0] > webtools-addon-sitemap@1.2.1 watch
webtools-addon-sitemap:watch:link: [0] > ../../../node_modules/.bin/pack-up watch
webtools-addon-sitemap:watch:link: [0]
strapi-plugin-webtools:watch:link: [0]
strapi-plugin-webtools:watch:link: [0] > strapi-plugin-webtools@1.4.1 watch
strapi-plugin-webtools:watch:link: [0] > pack-up watch
strapi-plugin-webtools:watch:link: [0]
webtools-addon-sitemap:watch:link: [0] '..' is not recognized as an internal or external command,
webtools-addon-sitemap:watch:link: [0] operable program or batch file.
webtools-addon-sitemap:watch:link: [0] npm error path C:\Projects\GitHub\strapi-webtools\packages\addons\sitemap
webtools-addon-sitemap:watch:link: [0] npm error workspace webtools-addon-sitemap@1.2.1
webtools-addon-sitemap:watch:link: [0] npm error location C:\Projects\GitHub\strapi-webtools\packages\addons\sitemap
webtools-addon-sitemap:watch:link: [0] npm error command failed
webtools-addon-sitemap:watch:link: [0] npm error command C:\WINDOWS\system32\cmd.exe /d /s /c ../../../node_modules/.bin/pack-up watch
webtools-addon-sitemap:watch:link: [0] npm run watch exited with code 1
webtools-addon-sitemap:watch:link: node:internal/process/promises:392
webtools-addon-sitemap:watch:link:       new UnhandledPromiseRejection(reason);
webtools-addon-sitemap:watch:link:       ^
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "[object Array]".
webtools-addon-sitemap:watch:link:     at throwUnhandledRejectionsMode (node:internal/process/promises:392:7)
webtools-addon-sitemap:watch:link:     at processPromiseRejections (node:internal/process/promises:475:17)
webtools-addon-sitemap:watch:link:     at process.processTicksAndRejections (node:internal/process/task_queues:106:32) {
webtools-addon-sitemap:watch:link:   code: 'ERR_UNHANDLED_REJECTION'
webtools-addon-sitemap:watch:link: }
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: Node.js v22.14.0
webtools-addon-sitemap:watch:link: ERROR: command finished with error: command (C:\Projects\GitHub\strapi-webtools\packages\addons\sitemap) C:\Users\Jorrit\AppData\Local\Temp\xfs-07627764\yarn.cmd run watch:link exited (1)    
webtools-addon-sitemap#watch:link: command (C:\Projects\GitHub\strapi-webtools\packages\addons\sitemap) C:\Users\Jorrit\AppData\Local\Temp\xfs-07627764\yarn.cmd run watch:link exited (1)

 Tasks:    0 successful, 2 total
Cached:    0 cached, 2 total
  Time:    3.699s
Failed:    webtools-addon-sitemap#watch:link

 ERROR  run failed: command  exited (1)
```

After:

```
PS C:\Projects\GitHub\strapi-webtools> yarn develop                                       
turbo 2.5.0

• Packages in scope: docs, strapi-plugin-webtools, webtools-addon-sitemap, webtools-cli
• Running watch:link in 4 packages
• Remote caching disabled
strapi-plugin-webtools:watch:link: cache bypass, force executing 115673eb70ec7dc4
webtools-addon-sitemap:watch:link: cache bypass, force executing dc7e68ebd97891b7
strapi-plugin-webtools:watch:link: [INFO] Watching ./dist for changes to files with extensions: ts,js,png,svg,gif,jpeg,css
strapi-plugin-webtools:watch:link:
strapi-plugin-webtools:watch:link: To use this package in Strapi, in a separate shell run:
strapi-plugin-webtools:watch:link: cd /path/to/strapi/project
strapi-plugin-webtools:watch:link:
strapi-plugin-webtools:watch:link: Then run one of the commands below based on the package manager used in that project:
strapi-plugin-webtools:watch:link:
strapi-plugin-webtools:watch:link: ## yarn
strapi-plugin-webtools:watch:link: yarn dlx yalc add --link strapi-plugin-webtools && yarn install
strapi-plugin-webtools:watch:link:
strapi-plugin-webtools:watch:link: ## npm
strapi-plugin-webtools:watch:link: npx yalc add strapi-plugin-webtools && npx yalc link strapi-plugin-webtools && npm install
webtools-addon-sitemap:watch:link: [INFO] Watching ./dist for changes to files with extensions: ts,js,png,svg,gif,jpeg,css
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: To use this package in Strapi, in a separate shell run:
webtools-addon-sitemap:watch:link: cd /path/to/strapi/project
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: Then run one of the commands below based on the package manager used in that project:
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: ## yarn
webtools-addon-sitemap:watch:link: yarn dlx yalc add --link webtools-addon-sitemap && yarn install
webtools-addon-sitemap:watch:link:
webtools-addon-sitemap:watch:link: ## npm
webtools-addon-sitemap:watch:link: npx yalc add webtools-addon-sitemap && npx yalc link webtools-addon-sitemap && npm install
strapi-plugin-webtools:watch:link: (node:46860) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
strapi-plugin-webtools:watch:link: (Use `node --trace-deprecation ...` to show where the warning was created)
webtools-addon-sitemap:watch:link: (node:51640) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
webtools-addon-sitemap:watch:link: (Use `node --trace-deprecation ...` to show where the warning was created)
strapi-plugin-webtools:watch:link: strapi-plugin-webtools@1.4.1 published in store.
webtools-addon-sitemap:watch:link: webtools-addon-sitemap@1.2.1 published in store.
strapi-plugin-webtools:watch:link: [0] 
strapi-plugin-webtools:watch:link: [0] > strapi-plugin-webtools@1.4.1 watch
strapi-plugin-webtools:watch:link: [0] > pack-up watch
strapi-plugin-webtools:watch:link: [0]
webtools-addon-sitemap:watch:link: [0] 
webtools-addon-sitemap:watch:link: [0] > webtools-addon-sitemap@1.2.1 watch
webtools-addon-sitemap:watch:link: [0] > pack-up watch
webtools-addon-sitemap:watch:link: [0]
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\cli\index.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [0] [SUCCESS]  Building Javascript (runtime: node – target: cjs)
webtools-addon-sitemap:watch:link: [0]     webtools-addon-sitemap\bundle_cjs_2: ./server/cli.js -> ./dist/cli/index.js
webtools-addon-sitemap:watch:link: [0] [SUCCESS]  Building Javascript (runtime: node – target: es)
webtools-addon-sitemap:watch:link: [0]     webtools-addon-sitemap\bundle_esm_2: ./server/cli.js -> ./dist/cli/index.mjs
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\server\index.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [0] [SUCCESS]  Building Javascript (runtime: node – target: cjs)
webtools-addon-sitemap:watch:link: [0]     webtools-addon-sitemap\bundle_cjs_1: ./server/index.js -> ./dist/server/index.js
webtools-addon-sitemap:watch:link: [0] [SUCCESS]  Building Javascript (runtime: node – target: es)
webtools-addon-sitemap:watch:link: [0]     webtools-addon-sitemap\bundle_esm_1: ./server/index.js -> ./dist/server/index.mjs
strapi-plugin-webtools:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\core\dist\server\index.js
strapi-plugin-webtools:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: Package content has not changed, skipping publishing.
webtools-addon-sitemap:watch:link: [0] "default" is imported from external module "react" but never used in "admin/components/EditView/index.jsx", "admin/components/Header/index.jsx", "admin/components/Loader/index.jsx", "admi
n/components/Info/index.jsx", "admin/components/HostnameModal/index.jsx", "admin/tabs/Settings/index.jsx", "admin/components/List/Collection/Row.jsx", "admin/components/List/Collection/index.jsx", "admin/components/List/Custom
/Row.jsx", "admin/components/List/Custom/index.jsx", "admin/tabs/CustomURLs/index.jsx", "admin/components/ModalForm/Custom/index.jsx", "admin/components/SelectContentTypes/index.jsx", "admin/components/ModalForm/Collection/index.jsx", "admin/components/ModalForm/index.jsx", "admin/tabs/CollectionURLs/index.jsx", "admin/components/Tabs/index.jsx", "admin/containers/Main/index.jsx" and "admin/containers/App/index.jsx".
strapi-plugin-webtools:watch:link: [0] [SUCCESS]  Building Javascript (runtime: node – target: es)
strapi-plugin-webtools:watch:link: [0]     strapi-plugin-webtools\bundle_esm_1: ./server/index.ts -> ./dist/server/index.mjs
strapi-plugin-webtools:watch:link: [0] [SUCCESS]  Building Javascript (runtime: node – target: cjs)
strapi-plugin-webtools:watch:link: [0]     strapi-plugin-webtools\bundle_cjs_1: ./server/index.ts -> ./dist/server/index.js
webtools-addon-sitemap:watch:link: [0] "default" is imported from external module "react" but never used in "admin/components/EditView/index.jsx", "admin/components/Loader/index.jsx", "admin/components/Header/index.jsx", "admi
n/components/Info/index.jsx", "admin/components/HostnameModal/index.jsx", "admin/tabs/Settings/index.jsx", "admin/components/List/Custom/Row.jsx", "admin/components/List/Custom/index.jsx", "admin/components/List/Collection/Row
.jsx", "admin/components/List/Collection/index.jsx", "admin/tabs/CollectionURLs/index.jsx", "admin/components/ModalForm/Custom/index.jsx", "admin/components/SelectContentTypes/index.jsx", "admin/components/ModalForm/Collection/index.jsx", "admin/components/ModalForm/index.jsx", "admin/tabs/CustomURLs/index.jsx", "admin/components/Tabs/index.jsx", "admin/containers/Main/index.jsx" and "admin/containers/App/index.jsx".
strapi-plugin-webtools:watch:link: Package content has not changed, skipping publishing.
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\admin\index.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\ar-C_tQu1XS.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\en-DGS0Do5c.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\de-CYgZ-6G5.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\es-DI7uYYEK.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\it-DYpuAHa5.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: Package content has not changed, skipping publishing.
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\fr-C4hzktsM.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\ja-DCK1QrYm.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\ko-Bgn4ZG2R.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\nl-Be4dsW3f.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\pl-waX2XGLw.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\pt-BR-B_ii8U63.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\pt-Cuc1TzHc.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\ru-Dc-rSPqb.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\uk-DuE_wRxU.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\tr-DZacWaso.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\zh-Hans-JcohXWfl.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\addons\sitemap\dist\_chunks\zh-BjcJQUQC.js
webtools-addon-sitemap:watch:link: [INFO] Pushing new yalc package...
webtools-addon-sitemap:watch:link: [0] [SUCCESS]  Building Javascript (runtime: web – target: es)
webtools-addon-sitemap:watch:link: [0]     webtools-addon-sitemap\bundle_esm_0: ./admin/index.js -> ./dist/admin/index.mjs
webtools-addon-sitemap:watch:link: [0] [SUCCESS]  Building Javascript (runtime: web – target: cjs)
webtools-addon-sitemap:watch:link: [0]     webtools-addon-sitemap\bundle_cjs_0: ./admin/index.js -> ./dist/admin/index.js
strapi-plugin-webtools:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\core\dist\admin\index.js
strapi-plugin-webtools:watch:link: [INFO] Pushing new yalc package...
strapi-plugin-webtools:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\core\dist\_chunks\index-CZNd9pf4.js
strapi-plugin-webtools:watch:link: [INFO] Pushing new yalc package...
strapi-plugin-webtools:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\core\dist\_chunks\en-ChRhiEgl.js
strapi-plugin-webtools:watch:link: [INFO] Pushing new yalc package...
strapi-plugin-webtools:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\core\dist\_chunks\index-3ODNGL3R.js
strapi-plugin-webtools:watch:link: [INFO] Pushing new yalc package...
strapi-plugin-webtools:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\core\dist\_chunks\es-Zq9JQWzn.js
strapi-plugin-webtools:watch:link: [INFO] Pushing new yalc package...
strapi-plugin-webtools:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\core\dist\_chunks\tr-5XsWIV-2.js
strapi-plugin-webtools:watch:link: [INFO] Pushing new yalc package...
strapi-plugin-webtools:watch:link: [INFO] Found changes in files: c:\Projects\GitHub\strapi-webtools\packages\core\dist\_chunks\nl-vG77TuoT.js
strapi-plugin-webtools:watch:link: [INFO] Pushing new yalc package...
strapi-plugin-webtools:watch:link: [0] [SUCCESS]  Building Javascript (runtime: web – target: es)
strapi-plugin-webtools:watch:link: [0]     strapi-plugin-webtools\bundle_esm_0: ./admin/index.ts -> ./dist/admin/index.mjs
strapi-plugin-webtools:watch:link: [0] [SUCCESS]  Building Javascript (runtime: web – target: cjs)
strapi-plugin-webtools:watch:link: [0]     strapi-plugin-webtools\bundle_cjs_0: ./admin/index.ts -> ./dist/admin/index.js
strapi-plugin-webtools:watch:link: Package content has not changed, skipping publishing.
webtools-addon-sitemap:watch:link: Package content has not changed, skipping publishing.
strapi-plugin-webtools:watch:link: Package content has not changed, skipping publishing.

 Tasks:    0 successful, 2 total
Cached:    0 cached, 2 total
  Time:    5.052s
```