### PR TITLE
fix: location of test db, awaiting strapi teardown

### DIFF
--- a/playground/config/env/test/database.ts
+++ b/playground/config/env/test/database.ts
@@ -2,14 +2,17 @@ import path from 'path';
 
 export default ({ env }) => ({
   connection: {
-    client: "sqlite",
+    client: 'sqlite',
     connection: {
       filename: path.join(
         __dirname,
+        // Get out of config/env/test
+        '..',
+        '..',
         '..',
         // We need to go back once more to get out of the dist folder
         '..',
-        env("DATABASE_TEST_FILENAME", ".tmp/test.db"),
+        env('DATABASE_TEST_FILENAME', '.tmp/test.db'),
       ),
     },
     useNullAsDefault: true,


### PR DESCRIPTION
### What does it do?

Improves developer experience by putting the temp db in playground/.tmp.
Adds typings to the test/helpers.ts file and adds/removes `await` where needed.

### Why is it needed?

I was trying to figure out where the data was stored while running the tests. This change puts the data in a more visible location. While debugging the tests, I added some typescript typings to the helper file and discovered that some calls were awaited that did not return a promise and one async call was not awaited.