### PR TITLE
feat: unique aliases per locale

### DIFF
--- a/.changeset/plain-states-reply.md
+++ b/.changeset/plain-states-reply.md
@@ -1,0 +1,6 @@
+---
+"strapi-plugin-webtools": minor
+"docs": patch
+---
+
+feat: unique aliases per locale

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,4 +11,5 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx|js|jsx)$': 'ts-jest',
   },
+  testTimeout: 30_000,
 };

--- a/packages/addons/sitemap/server/utils/enabledContentTypes.ts
+++ b/packages/addons/sitemap/server/utils/enabledContentTypes.ts
@@ -1,20 +1,8 @@
 import get from 'lodash/get';
-import { UID, Schema } from '@strapi/strapi';
+import { Schema } from '@strapi/strapi';
 
 
-export const isContentTypeEnabled = (ct: UID.ContentType) => {
-  let contentType: Schema.ContentType;
-
-  if (typeof ct === 'string') {
-    contentType = strapi.contentTypes[ct];
-  } else {
-    contentType = ct;
-  }
-
+export const isContentTypeEnabled = (contentType: Schema.ContentType) => {
   const { pluginOptions } = contentType;
-  const enabled = get(pluginOptions, ['webtools', 'enabled'], false) as boolean;
-
-  if (!enabled) return false;
-
-  return true;
+  return get(pluginOptions, ['webtools', 'enabled'], false) as boolean;
 };

--- a/packages/core/server/config.ts
+++ b/packages/core/server/config.ts
@@ -5,7 +5,8 @@ import kebabCase from 'lodash/kebabCase';
 export interface Config {
   website_url: string;
   default_pattern: string,
-  slugify: (fieldValue: string) => string
+  unique_per_locale: boolean,
+  slugify: (fieldValue: string) => string,
 }
 
 const config: {
@@ -16,6 +17,7 @@ const config: {
     website_url: null,
     default_pattern: '/[pluralName]/[documentId]',
     slugify: (fieldValue) => kebabCase(deburr(toLower(fieldValue))),
+    unique_per_locale: false,
   },
   validator() {},
 };

--- a/packages/core/server/content-types/url-alias/schema.json
+++ b/packages/core/server/content-types/url-alias/schema.json
@@ -25,7 +25,6 @@
     "url_path": {
       "type": "string",
       "required": true,
-      "unique": true,
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/packages/core/server/middlewares/generate-url-alias.ts
+++ b/packages/core/server/middlewares/generate-url-alias.ts
@@ -64,7 +64,7 @@ const generateUrlAliasMiddleware: Modules.Documents.Middleware.Middleware = asyn
     },
   });
 
-  // If the document already has an URL alias, fetch it.
+  // If the document already has a URL alias, fetch it.
   if (params.data.url_alias?.[0]) {
     urlAliasEntity = await strapi.documents('plugin::webtools.url-alias').findOne({
       ...(params.locale ? { locale: params.locale } : {}),

--- a/packages/core/server/middlewares/prevent-duplicate-urls.ts
+++ b/packages/core/server/middlewares/prevent-duplicate-urls.ts
@@ -18,15 +18,8 @@ const preventDuplicateUrlsMiddleware: Modules.Documents.Middleware.Middleware = 
   const params = context.params as Modules.Documents.ServiceParams<'plugin::webtools.url-alias'>['create' | 'update' | 'clone'] & { documentId: string };
 
   if (params.data.url_path) {
-    const excludeFilters: { [key: string]: any }[] = [];
-
-    excludeFilters.push({ documentId: params.documentId });
-
-    if (params.locale) {
-      excludeFilters.push({ locale: params.locale });
-    }
-
-    params.data.url_path = await getPluginService('url-alias').makeUniquePath(params.data.url_path, action !== 'clone' && excludeFilters);
+    params.data.url_path = await getPluginService('url-alias')
+      .makeUniquePath(params.data.url_path, action !== 'clone' && params.documentId, action !== 'clone' && params.locale);
   }
 
   return next();

--- a/packages/core/server/util/enabledContentTypes.ts
+++ b/packages/core/server/util/enabledContentTypes.ts
@@ -13,9 +13,6 @@ export const isContentTypeEnabled = (ct: Schema.ContentType) => {
   }
 
   const { pluginOptions } = contentType;
-  const enabled = get(pluginOptions, [pluginId, 'enabled'], false) as boolean;
 
-  if (!enabled) return false;
-
-  return true;
+  return get(pluginOptions, [pluginId, 'enabled'], false) as boolean;
 };

--- a/packages/docs/docs/configuration/unique-per-locale.md
+++ b/packages/docs/docs/configuration/unique-per-locale.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: 'Unique alias per locale'
+displayed_sidebar: webtoolsSidebar
+slug: /configuration/unique-per-locale
+---
+
+# Unique URL alias per locale
+
+By default Webtools generates URL aliases that are unique within entire Strapi database.
+When you use a separate domain name per locale this prevents reusing the same alias between locales.
+
+Set `unique_per_locale` to `true` to allow Webtools to generate the same alias as long as the locale is different.
+
+| Name | Details             |
+| ---- |---------------------|
+| Key | `unique_per_locale` |
+| Required | false               |
+| Type | boolean             |
+| Default | false               |

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -63,13 +63,20 @@ export default {
           .updateRole(publicRole.id, publicRole);
       }
 
+      await strapi.documents('plugin::i18n.locale').create({
+        data: {
+          code: 'nl',
+          name: 'Dutch (nl)',
+        },
+      });
+
       await strapi.documents('plugin::webtools.url-pattern').create({
         data: {
           pattern: '/page/[title]',
           label: 'Test API pattern',
           code: 'test_api_pattern',
           contenttype: 'api::test.test',
-          languages: ['en'],
+          languages: ['en', 'nl'],
         },
       });
 

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -19,6 +19,9 @@ export default {
   async bootstrap({ strapi }: { strapi: Core.Strapi }) {
     // Seed the database with some test data for the integration tests.
     if (process.env.NODE_ENV === 'test') {
+      // Hide repeated startup messages while running tests.
+      strapi.config.set('server.logger.startup.enabled', false);
+
       // Give the public role some permissions to test with
       const roles = await strapi
         .service('plugin::users-permissions.role')

--- a/playground/tests/healthcheck.test.js
+++ b/playground/tests/healthcheck.test.js
@@ -1,4 +1,4 @@
-const { setupStrapi, stopStrapi } = require("./helpers");
+const { setupStrapi, stopStrapi } = require('./helpers');
 
 jest.setTimeout(50000);
 
@@ -10,8 +10,8 @@ afterAll(async () => {
   await stopStrapi();
 });
 
-describe("Strapi is defined", () => {
-  it("just works", () => {
+describe('Strapi is defined', () => {
+  it('just works', () => {
     expect(strapi).toBeDefined();
   });
 });

--- a/playground/tests/helpers.ts
+++ b/playground/tests/helpers.ts
@@ -14,7 +14,8 @@ export async function setupStrapi() {
       appDir: './playground',
       distDir: './playground/dist',
     }).load();
-    strapi.server.mount();
+
+    await strapi.start();
 
     instance = strapi; // strapi is global now
   }
@@ -31,8 +32,6 @@ export async function stopStrapi() {
 
     assert(typeof tmpDbFile === 'string');
 
-    instance.server.httpServer.close();
-    await instance.db.connection.destroy();
     await instance.destroy();
 
     if (fs.existsSync(tmpDbFile)) {

--- a/playground/types/generated/contentTypes.d.ts
+++ b/playground/types/generated/contentTypes.d.ts
@@ -1139,7 +1139,6 @@ export interface PluginWebtoolsUrlAlias extends Struct.CollectionTypeSchema {
       Schema.Attribute.Private;
     url_path: Schema.Attribute.String &
       Schema.Attribute.Required &
-      Schema.Attribute.Unique &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;


### PR DESCRIPTION
### What does it do?

Adds an option to generate unique urls per locale instead of across the entire site.

### Why is it needed?

When the locale is already part of the URL (for instance, in the domain name or an externally provided path prefix) the URL does not need to be unique for the site, but just for the locale.

### How to test it?

1. Create Strapi content with multiple locales but the same value for the fields in the placeholder(s).
2. Create URL patterns for these locales that are identical for the locales
3. Set the new config option `unique_per_locale` to true.

### Related issue(s)/PR(s)

Addresses #289