### PR TITLE
Show spinner when bulk generating aliases

### DIFF
--- a/.changeset/happy-zoos-relate.md
+++ b/.changeset/happy-zoos-relate.md
@@ -1,0 +1,5 @@
+---
+"strapi-plugin-webtools": patch
+---
+
+show spinner when bulk generating aliases

--- a/packages/core/admin/containers/App/index.tsx
+++ b/packages/core/admin/containers/App/index.tsx
@@ -85,7 +85,7 @@ const App = () => {
         <Route path="/patterns/new" element={<PatternsCreatePage />} />
         <Route path="/patterns/:id" element={<PatternsEditPage />} />
         {routerComponents.map(({ path, Component }) => (
-          <Route path={path} element={<Component />} />
+          <Route key={path} path={path} element={<Component />} />
         ))}
 
         <Route path="*" element={<PageNotFound />} />

--- a/packages/core/admin/screens/List/components/GeneratePathsModal/index.tsx
+++ b/packages/core/admin/screens/List/components/GeneratePathsModal/index.tsx
@@ -62,6 +62,7 @@ const GeneratePathsModal = ({
               <Flex direction="column" alignItems="start" gap="1" marginTop="2">
                 {contentTypes.map((contentType) => (
                   <Checkbox
+                    key={contentType.uid}
                     aria-label={`Select ${contentType.name}`}
                     checked={selectedContentTypes.includes(contentType.uid)}
                     onCheckedChange={() => {

--- a/packages/core/admin/screens/List/components/GeneratePathsModal/index.tsx
+++ b/packages/core/admin/screens/List/components/GeneratePathsModal/index.tsx
@@ -140,7 +140,7 @@ const GeneratePathsModal = ({
           >
             {formatMessage({
               id: 'webtools.settings.button.generate_paths',
-              defaultMessage: 'Generate paths',
+              defaultMessage: 'Bulk generate',
             })}
           </Button>
         </Modal.Footer>

--- a/packages/core/admin/screens/List/components/GeneratePathsModal/index.tsx
+++ b/packages/core/admin/screens/List/components/GeneratePathsModal/index.tsx
@@ -25,7 +25,8 @@ const GeneratePathsModal = ({
   contentTypes,
   children,
 }: Props) => {
-  const [open, setOpen] = React.useState<boolean>();
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [submitting, setSubmitting] = React.useState<boolean>(false);
   const { formatMessage } = useIntl();
   const [selectedContentTypes, setSelectedContentTypes] = React.useState<EnabledContentType['uid'][]>([]);
   const [selectedGenerationType, setSelectedGenerationType] = React.useState<GenerationType>();
@@ -135,9 +136,15 @@ const GeneratePathsModal = ({
           <Button
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onClick={async () => {
-              await onSubmit(selectedContentTypes, selectedGenerationType);
-              setOpen(false);
+              try {
+                setSubmitting(true);
+                await onSubmit(selectedContentTypes, selectedGenerationType);
+                setOpen(false);
+              } finally {
+                setSubmitting(false);
+              }
             }}
+            loading={submitting}
           >
             {formatMessage({
               id: 'webtools.settings.button.generate_paths',

--- a/packages/core/admin/screens/List/index.tsx
+++ b/packages/core/admin/screens/List/index.tsx
@@ -85,7 +85,7 @@ const List = () => {
             <Button>
               {formatMessage({
                 id: 'webtools.settings.button.generate_paths',
-                defaultMessage: 'Generate paths',
+                defaultMessage: 'Bulk generate',
               })}
             </Button>
           </GeneratePathsModal>

--- a/packages/core/admin/screens/Overview/components/ContentTypesList/index.tsx
+++ b/packages/core/admin/screens/Overview/components/ContentTypesList/index.tsx
@@ -53,7 +53,7 @@ const ContentTypesList = (props: Props) => {
           </Thead>
           <Tbody>
             {contentTypes.map((contenttype) => (
-              <Tr>
+              <Tr key={contenttype.uid}>
                 <Td width="50%">
                   <Typography>{contenttype.name}</Typography>
                 </Td>

--- a/packages/core/admin/screens/Overview/index.tsx
+++ b/packages/core/admin/screens/Overview/index.tsx
@@ -156,6 +156,7 @@ const List = () => {
                     width: '240px',
                   }}
                   id="fourth"
+                  key={addon.info.name}
                 >
                   <CardBody>
                     <Box padding={2} background="primary100">

--- a/packages/core/server/services/bulk-generate.ts
+++ b/packages/core/server/services/bulk-generate.ts
@@ -35,11 +35,9 @@ const generateUrlAliases = async (params: GenerateParams): Promise<number> => {
     }
 
     let relations: string[] = [];
-    let languages: string[] = [undefined];
 
-    languages = [];
     const locales = await strapi.documents('plugin::i18n.locale').findMany({});
-    languages = locales.map((locale) => locale.code);
+    const languages = locales.map((locale) => locale.code);
 
     // Get all relations for the type
     await Promise.all(languages.map(async (lang) => {

--- a/packages/core/server/util/enabledContentTypes.ts
+++ b/packages/core/server/util/enabledContentTypes.ts
@@ -1,18 +1,8 @@
 import get from 'lodash/get';
 import { Schema } from '@strapi/strapi';
 
-import { pluginId } from './pluginId';
 
-export const isContentTypeEnabled = (ct: Schema.ContentType) => {
-  let contentType: Schema.ContentType;
-
-  if (typeof ct === 'string') {
-    contentType = strapi.contentTypes[ct];
-  } else {
-    contentType = ct;
-  }
-
+export const isContentTypeEnabled = (contentType: Schema.ContentType) => {
   const { pluginOptions } = contentType;
-
-  return get(pluginOptions, [pluginId, 'enabled'], false) as boolean;
+  return get(pluginOptions, ['webtools', 'enabled'], false) as boolean;
 };


### PR DESCRIPTION
### What does it do?

The primary goal was to show a spinner on the 'Bulk generate' button when generating. I also added some cosmetic changes in separate commits.

### Why is it needed?

It's easy to accidently click twice on the Bulk generate button as it provides no feedback. When this process is started twice, the results are either no or duplicate aliases.

### How to test it?

Start the playground, click the Bulk generate button. It should show a spinner.

<img width="276" height="92" alt="image" src="https://github.com/user-attachments/assets/e2f1c259-b1d2-458e-bf7e-e0a5aef893d3" />
