### PR TITLE
fix: issue with bulk generate when having DP and i18n enabled

### DIFF
--- a/.changeset/famous-trees-burn.md
+++ b/.changeset/famous-trees-burn.md
@@ -1,0 +1,5 @@
+---
+"strapi-plugin-webtools": patch
+---
+
+fix: issue with bulk generate when having DP and i18n enabled

--- a/packages/core/server/services/bulk-generate.ts
+++ b/packages/core/server/services/bulk-generate.ts
@@ -82,6 +82,7 @@ const generateUrlAliases = async (params: GenerateParams): Promise<number> => {
 
       // eslint-disable-next-line no-await-in-loop
       await strapi.documents(type as 'api::test.test').update({
+        locale: entity.locale,
         documentId: entity.documentId,
         data: {
           url_alias: [newUrlAlias.documentId],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

It solves an issue when using the Bulk Generate feature for content types which have both i18n and DP enabled.

### Why is it needed?

To solve #324 

### How to test it?

Install [1.7.1-beta.1](https://www.npmjs.com/package/strapi-plugin-webtools/v/1.7.1-beta.1) and see if the issue is resolved.

