### PR TITLE
Prevent an error when the user tries to update a non-existing entry

### DIFF
--- a/.changeset/khaki-dragons-love.md
+++ b/.changeset/khaki-dragons-love.md
@@ -1,0 +1,5 @@
+---
+"strapi-plugin-webtools": patch
+---
+
+fix: prevent an error when the user tries to update a non-existing entry

--- a/packages/core/server/middlewares/generate-url-alias.ts
+++ b/packages/core/server/middlewares/generate-url-alias.ts
@@ -46,6 +46,11 @@ const generateUrlAliasMiddleware: Modules.Documents.Middleware.Middleware = asyn
   // Fire the action.
   const entity = await next() as Modules.Documents.AnyDocument;
 
+  // Abort if no entity was created/updated.
+  if (!entity) {
+    return entity;
+  }
+
   // Fetch the full entity.
   const fullEntity = await strapi.documents(uid as 'api::test.test').findOne({
     documentId: entity.documentId,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

It prevents a 500 error when the user tries to update a non-existing entry.

### Why is it needed?

To prevent the 500 error.

