### PR TITLE
fix: filter duplicate URLs from the sitemap XML

### DIFF
--- a/.changeset/cold-nights-invent.md
+++ b/.changeset/cold-nights-invent.md
@@ -1,0 +1,5 @@
+---
+"webtools-addon-sitemap": patch
+---
+
+fix: filter duplicate URLs from the sitemap XML

--- a/packages/addons/sitemap/server/services/core.js
+++ b/packages/addons/sitemap/server/services/core.js
@@ -193,7 +193,17 @@ const createSitemapEntries = async () => {
     }
   }
 
-  return sitemapEntries;
+  // Filter out duplicates.
+  const allSitemapUrls = new Set();
+  const uniqueSitemapEntries = sitemapEntries.filter((entry) => {
+    if (allSitemapUrls.has(entry.url)) {
+      return false;
+    }
+    allSitemapUrls.add(entry.url);
+    return true;
+  });
+
+  return uniqueSitemapEntries;
 };
 
 /**


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

It filters out duplicate URLs from your sitemap XML.

### Why is it needed?

Because having duplicate URLs in your sitemap will get you penalized by Google.

### How to test it?

Create multiple of the same URL and generate a sitemap.
