### PR TITLE
fix(sitemap): trigger autoGenerate on publish and unpublish actions

### DIFF
--- a/.changeset/fix-autogenerate-publish-unpublish.md
+++ b/.changeset/fix-autogenerate-publish-unpublish.md
@@ -1,0 +1,7 @@
+---
+"webtools-addon-sitemap": patch
+---
+
+fix(sitemap): trigger autoGenerate on publish and unpublish actions
+
+In Strapi 5, publish and unpublish are separate document service actions and do not go through the update action. Adds both to the autoGenerateMiddleware allowlist so the sitemap regenerates immediately on publish/unpublish.

--- a/packages/addons/sitemap/server/middlewares/auto-generate.js
+++ b/packages/addons/sitemap/server/middlewares/auto-generate.js
@@ -17,8 +17,10 @@ const autoGenerateMiddleware = async (context, next) => {
     return next();
   }
 
-  // Only add the middleware for the create, update and delete action.
-  if (!['create', 'update', 'delete'].includes(action)) {
+  // Only add the middleware for the create, update, delete, publish and unpublish actions.
+  // In Strapi 5, publish and unpublish are separate document service actions and do not
+  // go through update, so they must be explicitly included here.
+  if (!['create', 'update', 'delete', 'publish', 'unpublish'].includes(action)) {
     return next();
   }
 


### PR DESCRIPTION
## Problem

`autoGenerate: true` does not regenerate the sitemap when a document is published or unpublished in Strapi 5. The sitemap only updates on the next cron tick.

Closes #416

## Root cause

The `autoGenerateMiddleware` allowlist only includes `create`, `update` and `delete`:

```js
if (!['create', 'update', 'delete'].includes(action)) {
  return next();
}
```

In Strapi 5, `publish` and `unpublish` are **separate document service actions** — they do not go through `update`. So publishing a document silently skips the middleware and the sitemap is never regenerated.

## Fix

Add `publish` and `unpublish` to the allowlist:

```js
if (!['create', 'update', 'delete', 'publish', 'unpublish'].includes(action)) {
  return next();
}
```

## Testing

1. Enable `autoGenerate: true` in plugin config with `excludeDrafts: true`
2. Create a new entry (saved as draft)
3. Publish the entry
4. Check `/api/sitemap/index.xml` — entry now appears immediately without waiting for cron
5. Unpublish the entry — entry is removed from sitemap immediately

## Related

- Fixes #416
- Related to #375