### PR TITLE
Fix bad URL when pattern refers to empty singular relationship

### DIFF
--- a/.changeset/cute-words-melt.md
+++ b/.changeset/cute-words-melt.md
@@ -1,0 +1,5 @@
+---
+"strapi-plugin-webtools": patch
+---
+
+Bad URL when pattern refers to empty singular relationship

--- a/packages/core/server/controllers/url-pattern.ts
+++ b/packages/core/server/controllers/url-pattern.ts
@@ -1,6 +1,5 @@
 
 
-import get from 'lodash/get';
 import { Context } from 'koa';
 import { factories, Schema, UID } from '@strapi/strapi';
 import { KoaContext } from '../types/koa';

--- a/packages/core/server/services/__tests__/url-pattern.test.ts
+++ b/packages/core/server/services/__tests__/url-pattern.test.ts
@@ -143,6 +143,21 @@ describe('URL Pattern Service', () => {
       // Current implementation replaces with empty string if missing.
       expect(resolved).toBe('/articles/my-article');
     });
+
+    it('test', () => {
+      const uid = 'api::category.category';
+      const entity = {
+        title: 'My Category',
+        test: undefined,
+      };
+      const pattern = '/category/[test.title]/[title]';
+
+      const resolved = service.resolvePattern(uid, entity, pattern);
+
+      // Should probably result in empty string for that part or handle it?
+      // Current implementation replaces with empty string if missing.
+      expect(resolved).toBe('/category/my-category');
+    });
   });
 
   describe('validatePattern', () => {
@@ -182,6 +197,7 @@ describe('URL Pattern Service', () => {
 
       expect(result.valid).toBe(true);
     });
+
     it('should invalidate pattern with forbidden fields', () => {
       const pattern = '/articles/[forbidden]/[title]';
       const allowedFields = ['title'];

--- a/packages/core/server/services/url-pattern.ts
+++ b/packages/core/server/services/url-pattern.ts
@@ -194,27 +194,26 @@ const customServices = () => ({
 
           const relationEntity = entity[relationName];
 
-          if (Array.isArray(relationEntity) && relationIndex !== null) {
-            const subEntity = relationEntity[relationIndex] as
-              | Record<string, unknown>
-              | undefined;
-            const value = subEntity?.[relationalField[1]];
-            resolvedPattern = resolvedPattern.replace(
-              `[${field}]`,
-              value ? slugify(String(value)) : '',
-            );
-          } else if (
-            typeof relationEntity === 'object'
-            && relationEntity !== null
-            && !Array.isArray(relationEntity)
-          ) {
+          if (Array.isArray(relationEntity)) {
+            if (relationIndex === null) {
+              strapi.log.error(`Pattern ${pattern} refers to plural relationship ${relationName}, but does not contain an index.`);
+              resolvedPattern = resolvedPattern.replace(`[${field}]`, '');
+            } else {
+              const subEntity = relationEntity[relationIndex] as
+                | Record<string, unknown>
+                | undefined;
+              const value = subEntity?.[relationalField[1]];
+              resolvedPattern = resolvedPattern.replace(
+                `[${field}]`,
+                value ? slugify(String(value)) : '',
+              );
+            }
+          } else {
             const value = (relationEntity as Record<string, unknown>)?.[relationalField[1]];
             resolvedPattern = resolvedPattern.replace(
               `[${field}]`,
               value ? slugify(String(value)) : '',
             );
-          } else {
-            strapi.log.error('Something went wrong whilst resolving the pattern.');
           }
         }
       });


### PR DESCRIPTION
### What does it do?

Since https://github.com/pluginpal/strapi-webtools/commit/661a844a3deb0a47a329d521552b04f1ab27757a I experience bad friendly urls when the pattern contains a reference to an optional manyToOne field and the field is empty.

### Why is it needed?

My pattern is `/over/[parent_page.slug]/[slug]`.
When my page contains no `parent_page`, the resulting friendly URL becomes `/over/[parent_page.slug]/cookies` instead of `/over/cookies`.
In addition, the following is logged to the server log:
`Something went wrong whilst resolving the pattern.`

### How to test it?

Create a content type with a manyToOne or One to One relationship.
Refer to this relationship in the URL pattern.
Generate the URL for an entity where this relationship is empty.